### PR TITLE
fix(deploy): adicionar packages:write ao job Build Docker Image para push no GHCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,9 @@ jobs:
     name: "3. Build Docker Image"
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
       image_sha: ${{ github.sha }}

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-03-26"
-branch_ativo: main
+branch_ativo: fix/docker-push-packages-write
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training


### PR DESCRIPTION
## Problema
Job **3. Build Docker Image** do `deploy.yml` falhava no step "Build and push" mesmo após login bem-sucedido no GHCR, porque o `GITHUB_TOKEN` não tinha a permissão `packages: write`.

## Causa raiz
O workflow não possuía bloco `permissions` em nenhum nível (workflow ou job). Para fazer push de imagens no GitHub Container Registry (GHCR) com `GITHUB_TOKEN`, é obrigatório declarar explicitamente `packages: write`.

## Fix aplicado
Adicionado ao job `build`:
```yaml
permissions:
  contents: read
  packages: write
```

## Impacto esperado
O job "Build and push" terá autorização para criar/atualizar o pacote `ghcr.io/hbtrack/hbtrack-backend`, permitindo que os jobs "4. Deploy → Staging" e "6. Deploy → Production" sejam executados.
