### PR TITLE
fix(ci): restaurar branch_ativo=main no SESSION_HANDOFF após merge PR #8

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-03-26"
-branch_ativo: fix/docker-push-packages-write
+branch_ativo: main
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training


### PR DESCRIPTION
## Problema
O squash merge do PR #8 carregou `SESSION_HANDOFF.md` com `branch_ativo: fix/docker-push-packages-write` para `main`.

O `HANDOFF_COHERENCE_GATE` no workflow de push para `main` executa com `git branch --show-current = "main"` (checkout nomeado, não detached HEAD), causando falha:
```
branch_ativo='fix/docker-push-packages-write' != branch atual='main'
```

## Fix
Restaura `branch_ativo: main` no SESSION_HANDOFF.md.

## Causa raiz sistêmica
Branches de fix curtas sempre causam este problema ao fazer squash merge incluindo SESSION_HANDOFF.md. A solução definitiva é nunca incluir SESSION_HANDOFF.md em branches de fix (excluir do squash via `.gitattributes` ou estratégia de merge), ou usar um valor especial para CI.
