### PR TITLE
fix(ci): reset volumes postgres no staging — elimina mismatch de credenciais DB

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -281,7 +281,10 @@ jobs:
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin 2>/dev/null || true
 
             docker compose -f infra/docker-compose.prod.yml pull
-            docker compose -f infra/docker-compose.prod.yml up -d --force-recreate
+            # Reset completo dos volumes em staging para evitar mismatch de credenciais DB
+            echo "🔄 Resetando volumes Docker (staging — dados efêmeros)..."
+            docker compose -f infra/docker-compose.prod.yml down -v 2>/dev/null || true
+            docker compose -f infra/docker-compose.prod.yml up -d
 
             echo "⏳ Aguardando API inicializar (30s)..."
             sleep 30


### PR DESCRIPTION
## Problema
O  foi regenerado em um deploy anterior (PR #12, quando estava corrompido com a PEM key), gerando novas senhas aleatórias para `DB_PASSWORD` / `POSTGRES_PASSWORD`.

O volume Docker do postgres **persistiu** com a senha anterior →  ao rodar `manage.py migrate`.

Stack trace capturado via PR #14:
```
django.db.utils.OperationalError: connection to server at "postgres" (172.21.0.3), port 5432 failed:
FATAL:  password authentication failed for user "hbtrack"
```

## Fix
Adicionar `docker compose down -v` antes de `docker compose up` no job de staging.

Em staging, dados são efêmeros — o reset garante que o postgres sempre inicializa com as credenciais do `.env` atual.

O deploy de **produção não é afetado**.

## Resultado esperado
-  consegue conectar ao postgres
- Gunicorn sobe em   
- Health check  → 200 ✅