### PR TITLE
fix(seed): created_by_user_id nas sessões de treino demo

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-03-26"
-branch_ativo: chore/sync-handoff-main
+branch_ativo: fix/seed-training-session-created-by
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -142,6 +142,7 @@ def seed():
                 "organization_id": ORG_ID,
                 "team_id": TEAM_ID,
                 "season_id": SEASON_ID,
+                "created_by_user_id": COACH_ID,
                 "session_at": session_at,
                 "session_type": stype,
                 "main_objective": f"Sessão demo #{i} — {stype}",


### PR DESCRIPTION
## Summary
- `seed_demo` falhava com `IntegrityError: null value in column "created_by_user_id"` ao criar as 5 sessões de treino demo
- Adiciona `created_by_user_id: COACH_ID` no `defaults` do `get_or_create`

## Test plan
- [ ] Merge → CI verde
- [ ] Deploy staging → rodar `python manage.py seed_demo` sem erro
- [ ] Staging populado com dados demo para testes E2E da FASE 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)