### PR TITLE
fix(identity_access): ProblemOut.type default 'about:blank' (era null)

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-03-27"
-branch_ativo: docs/infra-deploy-checklist
+branch_ativo: main
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training

--- a/src/identity_access/api.py
+++ b/src/identity_access/api.py
@@ -78,7 +78,7 @@ def _session_to_out(s) -> dict:
 
 
 def _problem(status: int, title: str, detail: str = "") -> dict:
-    return {"title": title, "status": status, "detail": detail or None}
+    return {"type": "about:blank", "title": title, "status": status, "detail": detail or None}
 
 
 # ── FT-011: Autenticação ──────────────────────────────────────────────────────

--- a/src/identity_access/schemas.py
+++ b/src/identity_access/schemas.py
@@ -80,7 +80,7 @@ class AssignRoleIn(Schema):
 
 class ProblemOut(Schema):
     """RFC 9457 Problem Details — application/problem+json."""
-    type: Optional[str] = None
+    type: str = "about:blank"
     title: str
     status: int
     detail: Optional[str] = None


### PR DESCRIPTION
## Problema

O Deploy Pipeline #27 falhou no Job 5 'Contract Conformance (Staging)'.

O `HTTP_RUNTIME_CONTRACT_GATE` (Schemathesis) detectou **25 violações de `response_schema_conformance`** em todos os endpoints `/api/auth/*`.

### Root cause

`src/identity_access/schemas.py` tinha:
```python
type: Optional[str] = None  # retornava null no JSON
```

O contrato OpenAPI define `type` como `string` com default `about:blank` (RFC 9457). Pydantic serializava `None` → `null`, violando o schema.

### Fix

- `src/identity_access/schemas.py`: `type: str = 'about:blank'`
- `src/identity_access/api.py`: `_problem()` agora inclui `'type': 'about:blank'` explicitamente

### Verificação local

- 884 testes passam
- Schemathesis reproduzido localmente: 25 violações desaparecem com o fix