### PR TITLE
fix(ci): schemathesis --request-timeout 10, subprocess timeout 120s→300s

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-03-27"
-branch_ativo: main
+branch_ativo: fix/schemathesis-timeout
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -6231,10 +6231,11 @@ def _g11_http_runtime_contract(root: pathlib.Path) -> dict:
         "--include-path-regex", r"^/api/(auth|users|teams|seasons|training)/",
         "--checks", "not_a_server_error,response_schema_conformance",
         "--max-examples", "5",
+        "--request-timeout", "10",
         "--no-color",
     ]
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120, cwd=str(root))
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=300, cwd=str(root))
         output = (proc.stdout + proc.stderr).strip()
     except FileNotFoundError:
         return _pg(gate_id, "FAIL", True, "ERROR_INFRA",
@@ -6244,7 +6245,7 @@ def _g11_http_runtime_contract(root: pathlib.Path) -> dict:
                    _ms(t0))
     except subprocess.TimeoutExpired:
         return _pg(gate_id, "FAIL", True, "ERROR_INFRA",
-                   "schemathesis excedeu timeout de 120s.",
+                   "schemathesis excedeu timeout de 300s.",
                    [], [], [],
                    [{"blocking_code": "ERROR_INFRA", "artifact": staging_url, "message": "timeout", "severity": "error"}],
                    _ms(t0))

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -67,10 +67,14 @@ class HBHookValidator:
             self.repo_root / "contracts" / "schemas" / "shared" / "session_start.schema.json"
         )
         self.validator_script = self.repo_root / "scripts" / "contracts" / "validate" / "validate_contracts.py"
-        
+
+        # Preferir Python da venv se disponível (git hook usa /usr/bin/python3 que pode não ter pytest)
+        _venv_python = self.repo_root / ".venv" / "bin" / "python"
+        self.python_bin = str(_venv_python) if _venv_python.exists() else sys.executable
+
         self.session: Dict[str, Any] = {}
         self.schema: Dict[str, Any] = {}
-        
+
         self.errors: List[str] = []
         self.warnings: List[str] = []
     
@@ -384,7 +388,7 @@ class HBHookValidator:
         # 1. Survival suite
         print("▶ HOOK [Gov 1/3]: Rodando survival-suite...")
         result = subprocess.run(
-            [sys.executable, str(hb_script), "survival-suite"],
+            [self.python_bin, str(hb_script), "survival-suite"],
             cwd=self.repo_root,
         )
         if result.returncode != 0:
@@ -399,7 +403,7 @@ class HBHookValidator:
         print("▶ HOOK [Gov 2/3]: Paridade schema/template/skills...")
         result = subprocess.run(
             [
-                sys.executable,
+                self.python_bin,
                 "-m",
                 "pytest",
                 "tests/pipeline_gates/test_schema_template_parity_phase4.py",
@@ -420,7 +424,7 @@ class HBHookValidator:
         print("▶ HOOK [Gov 3/3]: Validação cruzada SESSION_HANDOFF ↔ session_start...")
         result = subprocess.run(
             [
-                sys.executable,
+                self.python_bin,
                 "-m",
                 "pytest",
                 "tests/pipeline_gates/test_session_state_phase3.py",
@@ -451,7 +455,7 @@ class HBHookValidator:
         print("\n══ HOOK: Executando validate_contracts.py --profile precommit ══\n")
         
         result = subprocess.run(
-            [sys.executable, str(self.validator_script), "--profile", "precommit"],
+            [self.python_bin, str(self.validator_script), "--profile", "precommit"],
             cwd=self.repo_root
         )
         


### PR DESCRIPTION
## Problema

Deploy Pipeline #28 falhou no Job 5 com **timeout** no Schemathesis.

O step 'Run HTTP_RUNTIME_CONTRACT_GATE' durou 3m17s, mas o subprocess de Schemathesis tem limite de 120s.

### Root cause

80 operações testadas (9 auth + 4 users + 8 teams + 6 seasons + **53 training**) × 5 exemplos = **400 requests**. Com latência de rede do runner Azure East US → staging, 120s é insuficiente.

Note: o PR #26 (fix do `type: null`) já foi mergeado — este PR é o próximo problema na mesma cadeia.

### Fix

- **`validate_contracts.py`**: adicionado `--request-timeout 10` ao comando Schemathesis; subprocess timeout 120→300s
- **`scripts/git-hooks/pre-commit`**: hook agora detecta e usa `.venv/bin/python` quando disponível — resolve falha da survival-suite no hook local (`No module named pytest` com `/usr/bin/python3`)

### Governança

- Survival-suite: **94 passed** (3m17s)
- Paridade schema/template/skills: **33 passed**
- Validação cruzada SESSION_HANDOFF ↔ session_start: **27 passed**
- Pre-commit hook: **PASS**