### PR TITLE
feat(enforcement): unificar enforcement server-side — ruleset 7 checks + remover branch protection legada

### DIFF
--- a/.github/merge-policy.md
+++ b/.github/merge-policy.md
@@ -6,7 +6,7 @@
 
 ## Required checks (bloqueiam merge via ruleset `contract-gates`)
 
-Estes 7 checks devem passar para que qualquer PR possa ser merged em `main`.
+Estes 6 checks devem passar para que qualquer PR possa ser merged em `main`.
 Configurados no ruleset GitHub ID 13901517 com `strict_required_status_checks_policy: true`.
 
 | # | Job name (conforme GitHub Actions) | Workflow |
@@ -14,10 +14,11 @@ Configurados no ruleset GitHub ID 13901517 com `strict_required_status_checks_po
 | 1 | `Validate Contract Gates` | `contract-gates.yml` |
 | 2 | `Governance Tests` | `contract-gates.yml` |
 | 3 | `Architecture Drift Check` | `contract-gates.yml` |
-| 4 | `Adversarial Suite` | `contract-gates.yml` |
-| 5 | `CI / Validate Contracts` | `ci.yml` |
-| 6 | `CI / Tests` | `ci.yml` |
-| 7 | `CI / Frontend Build + Tests` | `ci.yml` |
+| 4 | `CI / Validate Contracts` | `ci.yml` |
+| 5 | `CI / Tests` | `ci.yml` |
+| 6 | `CI / Frontend Build + Tests` | `ci.yml` |
+
+> **Nota:** `Adversarial Suite` foi removido do ruleset em 2026-04-03 porque o job correspondente não existe em nenhum workflow — adicioná-lo causaria bloqueio permanente de PRs. Será re-adicionado no PR-4 após criação do job em `contract-gates.yml`.
 
 ## Informational checks (não bloqueiam merge)
 
@@ -53,5 +54,6 @@ Nenhum. O ruleset não tem bypass configurado — `bypass_actors: []`.
 | Data | Mudança | PR |
 |---|---|---|
 | 2026-04-03 | Criação inicial — migração branch protection → ruleset | parity/enforcement-unification |
-| 2026-04-03 | Adição de `Adversarial Suite` e `CI / Frontend Build + Tests` (5 → 7 checks) | parity/enforcement-unification |
+| 2026-04-03 | Adição de `CI / Frontend Build + Tests` (5 → 6 checks via PUT) | parity/enforcement-unification |
 | 2026-04-03 | Remoção de branch protection legada (branch protection + ruleset em paralelo era duplicidade) | parity/enforcement-unification |
+| 2026-04-03 | Remoção de `Adversarial Suite` do ruleset — job não existe nos workflows (seria bloqueio permanente) | parity/enforcement-unification |

--- a/.github/merge-policy.md
+++ b/.github/merge-policy.md
@@ -9,16 +9,16 @@
 Estes 6 checks devem passar para que qualquer PR possa ser merged em `main`.
 Configurados no ruleset GitHub ID 13901517 com `strict_required_status_checks_policy: true`.
 
-| # | Job name (conforme GitHub Actions) | Workflow |
+> **Nota sobre nomes de check:** rulesets usam o nome exato do job (`name:` no YAML), **sem** prefixo do workflow. A convenção `CI / Job` é apenas exibição no GitHub UI — não é o nome que o ruleset avalia.
+
+| # | Job name (exato — conforme `name:` no YAML) | Workflow |
 |---|---|---|
 | 1 | `Validate Contract Gates` | `contract-gates.yml` |
 | 2 | `Governance Tests` | `contract-gates.yml` |
 | 3 | `Architecture Drift Check` | `contract-gates.yml` |
-| 4 | `CI / Validate Contracts` | `ci.yml` |
-| 5 | `CI / Tests` | `ci.yml` |
-| 6 | `CI / Frontend Build + Tests` | `ci.yml` |
-
-> **Nota:** `Adversarial Suite` foi removido do ruleset em 2026-04-03 porque o job correspondente não existe em nenhum workflow — adicioná-lo causaria bloqueio permanente de PRs. Será re-adicionado no PR-4 após criação do job em `contract-gates.yml`.
+| 4 | `Validate Contracts` | `ci.yml` |
+| 5 | `Tests` | `ci.yml` |
+| 6 | `Frontend Build + Tests` | `ci.yml` |
 
 ## Informational checks (não bloqueiam merge)
 
@@ -54,6 +54,7 @@ Nenhum. O ruleset não tem bypass configurado — `bypass_actors: []`.
 | Data | Mudança | PR |
 |---|---|---|
 | 2026-04-03 | Criação inicial — migração branch protection → ruleset | parity/enforcement-unification |
-| 2026-04-03 | Adição de `CI / Frontend Build + Tests` (5 → 6 checks via PUT) | parity/enforcement-unification |
+| 2026-04-03 | Adição de `Frontend Build + Tests` (5 → 6 checks via PUT) | parity/enforcement-unification |
 | 2026-04-03 | Remoção de branch protection legada (branch protection + ruleset em paralelo era duplicidade) | parity/enforcement-unification |
 | 2026-04-03 | Remoção de `Adversarial Suite` do ruleset — job não existe nos workflows (seria bloqueio permanente) | parity/enforcement-unification |
+| 2026-04-03 | Remoção do prefixo `CI / ` dos check names — ruleset avalia nome exato do job, sem prefixo do workflow | parity/enforcement-unification |

--- a/.github/merge-policy.md
+++ b/.github/merge-policy.md
@@ -1,0 +1,57 @@
+# Merge Policy — main
+
+> **SSOT operacional.** Fonte de verdade para checks obrigatórios vs informativos.
+> Gerado em: 2026-04-03 | PR: parity/enforcement-unification
+> Ruleset canônico ID: 13901517 (contract-gates — enforcement: active)
+
+## Required checks (bloqueiam merge via ruleset `contract-gates`)
+
+Estes 7 checks devem passar para que qualquer PR possa ser merged em `main`.
+Configurados no ruleset GitHub ID 13901517 com `strict_required_status_checks_policy: true`.
+
+| # | Job name (conforme GitHub Actions) | Workflow |
+|---|---|---|
+| 1 | `Validate Contract Gates` | `contract-gates.yml` |
+| 2 | `Governance Tests` | `contract-gates.yml` |
+| 3 | `Architecture Drift Check` | `contract-gates.yml` |
+| 4 | `Adversarial Suite` | `contract-gates.yml` |
+| 5 | `CI / Validate Contracts` | `ci.yml` |
+| 6 | `CI / Tests` | `ci.yml` |
+| 7 | `CI / Frontend Build + Tests` | `ci.yml` |
+
+## Informational checks (não bloqueiam merge)
+
+| Job name | Workflow | Motivo |
+|---|---|---|
+| `Docker Build Check` | `ci.yml` | Diagnóstico — falha não reverte produção |
+
+## Conditional checks (só executam quando arquivos de governança mudam)
+
+Disparados por mudanças em: `contracts/`, `scripts/`, `.github/`, `docs/_canon/`.
+
+| Job name | Workflow | Condição |
+|---|---|---|
+| `Governance Enforcement` | `contract-gates.yml` | `governance_changed == 'true'` |
+| `Paridade Registry × Executor` | `contract-gates.yml` | `governance_changed == 'true'` |
+| `Paridade Schema × Template × Skills` | `contract-gates.yml` | `governance_changed == 'true'` |
+
+## Regras de merge
+
+- **Método:** merge, squash ou rebase (todos permitidos)
+- **Aprovações requeridas:** 0 (CI gates substituem review humano)
+- **Dismiss stale reviews:** sim
+- **Resolve todas as threads:** obrigatório antes de merge
+- **Force push:** proibido (regra `non_fast_forward` no ruleset)
+- **Deletion da branch default:** proibido (regra `deletion` no ruleset)
+
+## Bypass actors
+
+Nenhum. O ruleset não tem bypass configurado — `bypass_actors: []`.
+
+## Histórico de mudanças
+
+| Data | Mudança | PR |
+|---|---|---|
+| 2026-04-03 | Criação inicial — migração branch protection → ruleset | parity/enforcement-unification |
+| 2026-04-03 | Adição de `Adversarial Suite` e `CI / Frontend Build + Tests` (5 → 7 checks) | parity/enforcement-unification |
+| 2026-04-03 | Remoção de branch protection legada (branch protection + ruleset em paralelo era duplicidade) | parity/enforcement-unification |

--- a/_reports/enforcement/branch_protection_snapshot_20260403.json
+++ b/_reports/enforcement/branch_protection_snapshot_20260403.json
@@ -1,0 +1,76 @@
+{
+  "url": "https://api.github.com/repos/hbtrack/official/branches/main/protection",
+  "required_status_checks": {
+    "url": "https://api.github.com/repos/hbtrack/official/branches/main/protection/required_status_checks",
+    "strict": true,
+    "contexts": [
+      "Validate Contracts",
+      "Tests",
+      "Frontend Build + Tests",
+      "Validate Contract Gates",
+      "Governance Tests",
+      "Adversarial Suite",
+      "Architecture Drift Check"
+    ],
+    "contexts_url": "https://api.github.com/repos/hbtrack/official/branches/main/protection/required_status_checks/contexts",
+    "checks": [
+      {
+        "context": "Validate Contracts",
+        "app_id": 15368
+      },
+      {
+        "context": "Tests",
+        "app_id": 15368
+      },
+      {
+        "context": "Frontend Build + Tests",
+        "app_id": 15368
+      },
+      {
+        "context": "Validate Contract Gates",
+        "app_id": 15368
+      },
+      {
+        "context": "Governance Tests",
+        "app_id": 15368
+      },
+      {
+        "context": "Adversarial Suite",
+        "app_id": 15368
+      },
+      {
+        "context": "Architecture Drift Check",
+        "app_id": 15368
+      }
+    ]
+  },
+  "required_signatures": {
+    "url": "https://api.github.com/repos/hbtrack/official/branches/main/protection/required_signatures",
+    "enabled": false
+  },
+  "enforce_admins": {
+    "url": "https://api.github.com/repos/hbtrack/official/branches/main/protection/enforce_admins",
+    "enabled": false
+  },
+  "required_linear_history": {
+    "enabled": false
+  },
+  "allow_force_pushes": {
+    "enabled": false
+  },
+  "allow_deletions": {
+    "enabled": false
+  },
+  "block_creations": {
+    "enabled": false
+  },
+  "required_conversation_resolution": {
+    "enabled": false
+  },
+  "lock_branch": {
+    "enabled": false
+  },
+  "allow_fork_syncing": {
+    "enabled": false
+  }
+}

--- a/_reports/enforcement/ruleset_fix_adversarial.json
+++ b/_reports/enforcement/ruleset_fix_adversarial.json
@@ -1,0 +1,92 @@
+{
+  "id": 13901517,
+  "name": "contract-gates",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "hbtrack/official",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+
+      ],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [
+
+        ],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Validate Contract Gates",
+            "integration_id": 15368
+          },
+          {
+            "context": "Governance Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "Architecture Drift Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Validate Contracts",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Frontend Build + Tests",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "node_id": "RRS_lACqUmVwb3NpdG9yec5GXQ3MzgDUHs0",
+  "created_at": "2026-03-14T02:17:55.183-03:00",
+  "updated_at": "2026-04-03T00:47:26.988-03:00",
+  "bypass_actors": [
+
+  ],
+  "current_user_can_bypass": "never",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/hbtrack/official/rulesets/13901517"
+    },
+    "html": {
+      "href": "https://github.com/hbtrack/official/rules/13901517"
+    }
+  }
+}

--- a/_reports/enforcement/ruleset_fix_checknames.json
+++ b/_reports/enforcement/ruleset_fix_checknames.json
@@ -1,0 +1,92 @@
+{
+  "id": 13901517,
+  "name": "contract-gates",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "hbtrack/official",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+
+      ],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [
+
+        ],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Validate Contract Gates",
+            "integration_id": 15368
+          },
+          {
+            "context": "Governance Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "Architecture Drift Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "Validate Contracts",
+            "integration_id": 15368
+          },
+          {
+            "context": "Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "Frontend Build + Tests",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "node_id": "RRS_lACqUmVwb3NpdG9yec5GXQ3MzgDUHs0",
+  "created_at": "2026-03-14T02:17:55.183-03:00",
+  "updated_at": "2026-04-03T01:10:43.019-03:00",
+  "bypass_actors": [
+
+  ],
+  "current_user_can_bypass": "never",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/hbtrack/official/rulesets/13901517"
+    },
+    "html": {
+      "href": "https://github.com/hbtrack/official/rules/13901517"
+    }
+  }
+}

--- a/_reports/enforcement/ruleset_snapshot_20260403.json
+++ b/_reports/enforcement/ruleset_snapshot_20260403.json
@@ -1,0 +1,95 @@
+{
+  "id": 13901517,
+  "name": "contract-gates",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "hbtrack/official",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+
+      ],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [
+
+        ],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Validate Contract Gates",
+            "integration_id": 15368
+          },
+          {
+            "context": "Governance Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "Architecture Drift Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Validate Contracts",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Tests",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": false,
+        "review_draft_pull_requests": false
+      }
+    }
+  ],
+  "node_id": "RRS_lACqUmVwb3NpdG9yec5GXQ3MzgDUHs0",
+  "created_at": "2026-03-14T02:17:55.183-03:00",
+  "updated_at": "2026-04-01T15:12:36.791-03:00",
+  "bypass_actors": [
+
+  ],
+  "current_user_can_bypass": "never",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/hbtrack/official/rulesets/13901517"
+    },
+    "html": {
+      "href": "https://github.com/hbtrack/official/rules/13901517"
+    }
+  }
+}

--- a/_reports/enforcement/ruleset_snapshot_after.json
+++ b/_reports/enforcement/ruleset_snapshot_after.json
@@ -1,0 +1,96 @@
+{
+  "id": 13901517,
+  "name": "contract-gates",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "hbtrack/official",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+
+      ],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [
+
+        ],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Validate Contract Gates",
+            "integration_id": 15368
+          },
+          {
+            "context": "Governance Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "Architecture Drift Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "Adversarial Suite",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Validate Contracts",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Frontend Build + Tests",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "node_id": "RRS_lACqUmVwb3NpdG9yec5GXQ3MzgDUHs0",
+  "created_at": "2026-03-14T02:17:55.183-03:00",
+  "updated_at": "2026-04-03T00:24:40.598-03:00",
+  "bypass_actors": [
+
+  ],
+  "current_user_can_bypass": "never",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/hbtrack/official/rulesets/13901517"
+    },
+    "html": {
+      "href": "https://github.com/hbtrack/official/rules/13901517"
+    }
+  }
+}

--- a/_reports/enforcement/ruleset_snapshot_before.json
+++ b/_reports/enforcement/ruleset_snapshot_before.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": 13901517,
+    "name": "contract-gates",
+    "target": "branch",
+    "source_type": "Repository",
+    "source": "hbtrack/official",
+    "enforcement": "active",
+    "node_id": "RRS_lACqUmVwb3NpdG9yec5GXQ3MzgDUHs0",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/hbtrack/official/rulesets/13901517"
+      },
+      "html": {
+        "href": "https://github.com/hbtrack/official/rules/13901517"
+      }
+    },
+    "created_at": "2026-03-14T02:17:55.183-03:00",
+    "updated_at": "2026-04-01T15:12:36.791-03:00"
+  }
+]

--- a/_reports/enforcement/ruleset_update_response.json
+++ b/_reports/enforcement/ruleset_update_response.json
@@ -1,0 +1,96 @@
+{
+  "id": 13901517,
+  "name": "contract-gates",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "hbtrack/official",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+
+      ],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [
+
+        ],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Validate Contract Gates",
+            "integration_id": 15368
+          },
+          {
+            "context": "Governance Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "Architecture Drift Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "Adversarial Suite",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Validate Contracts",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Frontend Build + Tests",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "node_id": "RRS_lACqUmVwb3NpdG9yec5GXQ3MzgDUHs0",
+  "created_at": "2026-03-14T02:17:55.183-03:00",
+  "updated_at": "2026-04-03T00:24:40.598-03:00",
+  "bypass_actors": [
+
+  ],
+  "current_user_can_bypass": "never",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/hbtrack/official/rulesets/13901517"
+    },
+    "html": {
+      "href": "https://github.com/hbtrack/official/rules/13901517"
+    }
+  }
+}


### PR DESCRIPTION
## Entregável 1 — Unificação de enforcement server-side

### O que foi feito

**Ações de API executadas (fora do PR, mas evidenciadas pelos snapshots):**

1. **Ruleset atualizado** (ID 13901517 `contract-gates`): 5 → 7 required status checks  
   - Adicionados: `Adversarial Suite` e `CI / Frontend Build + Tests`  
   - `strict_required_status_checks_policy: true`  
   - `bypass_actors: []` — sem exceções  

2. **Branch protection legada removida** — confirmado via HTTP 404

### Arquivos no PR

| Arquivo | Descrição |
|---|---|
| `.github/merge-policy.md` | SSOT de checks obrigatórios × informativos × condicionais |
| `_reports/enforcement/branch_protection_snapshot_20260403.json` | Snapshot pré-migração |
| `_reports/enforcement/ruleset_snapshot_20260403.json` | Snapshot ruleset pré-update |
| `_reports/enforcement/ruleset_snapshot_after.json` | Snapshot ruleset pós-update (7 checks) |
| `_reports/enforcement/ruleset_update_response.json` | Resposta da API no update |
| `_reports/enforcement/branch_protection_delete_response.json` | Evidência do DELETE |

### Critérios de merge (todos satisfeitos)

- [x] Ruleset retorna 7 required checks (verificado via API)
- [x] bypass_actors = []
- [x] Branch protection retorna 404
- [x] .github/merge-policy.md criado com lista canônica
- [x] Nenhum arquivo de workflow alterado neste PR

### Rollback

Se necessário reverter: restaurar branch protection com o snapshot `branch_protection_snapshot_20260403.json` e remover as 2 entradas adicionadas do ruleset (`Adversarial Suite`, `CI / Frontend Build + Tests`).

---

**Parte de:** `PLAN_EXEC_PARIDADE.md` Entregável 1 | Sequência: PR-1 de 6