### PR TITLE
feat(parity/E3): merge-readiness manifest — SSOT de checks que bloqueiam merge

### DIFF
--- a/PLAN_EXEC_PARIDADE.md
+++ b/PLAN_EXEC_PARIDADE.md
@@ -1,0 +1,1365 @@
+# Plano Executivo de Paridade Local × GitHub
+
+Data: 2026-04-02 | Última atualização: 2026-04-03
+Base: diagnóstico validado ao vivo em `PLAN_PARIEDADE.md`
+Escopo: 6 entregáveis obrigatórios, sequenciais, com critério de aceite binário.
+Revisão: ajustes incorporados após revisão humana de 2026-04-03.
+Baseline: congelado em 2026-04-03 — SHA256 `424ba943be2f...` (1340 linhas pré-freeze).
+Execução: 1 PR por entregável; caso encerrado somente após Entregável 6 verde.
+
+> **Estado em 2026-04-03:** Entregável 1 **merged** — PR #31 merged em `main` às 04:18 UTC (merge commit `eb15c1f6`). Entregável 2 **merged** — PR #32 merged em `main` (squash commit `a83fd57b`). Entregáveis 3–6 pendentes.
+
+---
+
+## Entregável 1 — Unificação de enforcement server-side ✅ CONCLUÍDO (PR #31)
+
+### Problema que resolve
+
+Hoje existem **dois mecanismos ativos em paralelo** na `main`:
+- Branch protection legada: 7 required checks, `enforce_admins: false` (admin pode bypassar).
+- Ruleset `contract-gates`: 5 required checks, `bypass_actors: []` (ninguém pode bypassar).
+
+A dualidade cria ambiguidade operacional: qual é a fonte de verdade? Admin pode ou não pode bypassar? A resposta depende de qual camada intercepta primeiro.
+
+### Dependências
+
+Nenhuma. Este é o primeiro entregável.
+
+### Arquivos a alterar
+
+Nenhum arquivo versionado. Ação exclusivamente via GitHub Settings API ou UI.
+
+### Mudanças exatas
+
+> **Ordem de execução segura**: exportar estado → atualizar ruleset → validar ruleset → remover branch protection. Nunca remover antes de validar. Objetivo: janela de configuração incorreta = zero.
+
+**1. Exportar e registrar o estado atual (snapshot de segurança):**
+
+```bash
+# Salvar branch protection legada:
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/hbtrack/official/branches/main/protection" \
+  | tee _reports/enforcement/branch_protection_snapshot_$(date +%Y%m%d).json
+
+# Salvar ruleset atual:
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/hbtrack/official/rulesets/13901517" \
+  | tee _reports/enforcement/ruleset_snapshot_$(date +%Y%m%d).json
+```
+
+> Esses snapshots permitem rollback manual se algo der errado nos passos seguintes.
+
+**2. Atualizar o ruleset `contract-gates` (ID 13901517) para cobrir todos os checks reais:**
+
+Adicionar os checks ausentes. O ruleset atual tinha 5; o alvo final são 7 quando o job `Adversarial Suite` existir (PR-4). Estado pós PR #31:
+
+| Check | Workflow | Status pós PR #31 |
+|---|---|---|
+| `Validate Contract Gates` | contract-gates.yml | ✅ Presente |
+| `Governance Tests` | contract-gates.yml | ✅ Presente |
+| `Architecture Drift Check` | contract-gates.yml | ✅ Presente |
+| `CI / Validate Contracts` | ci.yml | ✅ Presente |
+| `CI / Tests` | ci.yml | ✅ Presente |
+| `CI / Frontend Build + Tests` | ci.yml | ✅ Adicionado em PR #31 |
+| `Adversarial Suite` | contract-gates.yml | ⏳ Aguarda criação do job (PR-4) — removido do ruleset para não bloquear PRs |
+
+> **Decisão de design (2026-04-03):** `Adversarial Suite` foi inicialmente adicionado ao ruleset mas removido em seguida após review do Codex bot (P1): o job não existe em nenhum workflow — required check sem job correspondente bloqueia PRs permanentemente. Será re-adicionado no PR-4 após criação do job em `contract-gates.yml`. Ruleset fechou em **6 required checks** (não 7).
+
+```bash
+# Via API — PUT para atualizar o ruleset com os 7 checks:
+curl -X PUT \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/hbtrack/official/rulesets/13901517" \
+  -d '{
+    "name": "contract-gates",
+    "enforcement": "active",
+    "conditions": {
+      "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
+    },
+    "rules": [
+      { "type": "deletion" },
+      { "type": "non_fast_forward" },
+      {
+        "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 0,
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_review_thread_resolution": true,
+          "allowed_merge_methods": ["merge", "squash", "rebase"]
+        }
+      },
+      {
+        "type": "required_status_checks",
+        "parameters": {
+          "strict_required_status_checks_policy": true,
+          "do_not_enforce_on_create": false,
+          "required_status_checks": [
+            { "context": "Validate Contract Gates", "integration_id": 15368 },
+            { "context": "Governance Tests", "integration_id": 15368 },
+            { "context": "Architecture Drift Check", "integration_id": 15368 },
+            { "context": "Adversarial Suite", "integration_id": 15368 },
+            { "context": "CI / Validate Contracts", "integration_id": 15368 },
+            { "context": "CI / Tests", "integration_id": 15368 },
+            { "context": "CI / Frontend Build + Tests", "integration_id": 15368 }
+          ]
+        }
+      }
+    ],
+    "bypass_actors": []
+  }'
+```
+
+**3. Validar que o ruleset novo está correto (antes de remover a proteção legada):**
+
+```bash
+# Confirmar que o ruleset agora tem 7 checks:
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/hbtrack/official/rulesets/13901517" \
+  | jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks | length'
+# Deve retornar: 7
+
+# Confirmar bypass_actors vazio:
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/hbtrack/official/rulesets/13901517" \
+  | jq '.bypass_actors'
+# Deve retornar: []
+```
+
+> **BLOQUEIO**: Se a validação acima falhar, NÃO prosseguir para o passo 4. Corrigir o ruleset primeiro.
+
+**4. Remover branch protection legada da `main` (só após validação do passo 3):**
+
+```bash
+curl -X DELETE \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/hbtrack/official/branches/main/protection"
+```
+
+**5. Documentar quais checks são required vs informativos:**
+
+Criar `.github/merge-policy.md` com a lista oficial (entregável 3 formaliza isso como manifesto versionado; aqui é o bootstrap mínimo).
+
+### Critério de aceite
+
+- [x] `GET /repos/hbtrack/official/branches/main/protection` retorna `404` (branch protection removida). ✅ confirmado 2026-04-03
+- [x] `GET /repos/hbtrack/official/rulesets/13901517` retorna 6 required checks (7 após PR-4), `bypass_actors: []`, `enforcement: "active"`. ✅ confirmado 2026-04-03
+- [x] PR de teste: PR #31 mergeado em `main` às 04:18 UTC — required checks satisfeitos via CI. ✅ 2026-04-03
+
+### Evidências geradas
+
+| Arquivo | Conteúdo |
+|---|---|
+| `_reports/enforcement/branch_protection_snapshot_20260403.json` | Estado da branch protection antes da remoção |
+| `_reports/enforcement/ruleset_snapshot_20260403.json` | Estado do ruleset antes do update |
+| `_reports/enforcement/ruleset_snapshot_after.json` | Estado do ruleset após update (6 checks) |
+| `_reports/enforcement/ruleset_update_response.json` | Resposta da API no PUT |
+| `_reports/enforcement/ruleset_fix_adversarial.json` | Evidência da remoção do `Adversarial Suite` |
+| `_reports/enforcement/branch_protection_delete_response.json` | Evidência do DELETE (body vazio = 204) |
+| `.github/merge-policy.md` | SSOT canônico de checks obrigatórios × informativos × condicionais |
+
+### Risco eliminado
+
+- Admin bypass via `enforce_admins: false`. ✅
+- Ambiguidade operacional entre dois mecanismos de enforcement. ✅
+- `CI / Frontend Build + Tests` passando sem ser required. ✅
+- `Adversarial Suite` como required check fantasma (bloqueio permanente de PRs). ✅ removido — PR-4 cria o job.
+
+### Validação de paridade
+
+Não impacta paridade local diretamente — enforcement é server-side. Mas elimina a possibilidade de merge sem checks verdes, o que é o pré-requisito para que qualquer paridade local tenha consequência real.
+
+---
+
+## Entregável 2 — Manifesto canônico de toolchain
+
+### Problema que resolve
+
+Versões estão espalhadas em 6+ arquivos sem SSOT:
+
+| Dimensão | Fontes conflitantes |
+|---|---|
+| Node | `.nvmrc` → `v24.14.0`, `ci.yml` → `"22"`, `contract-gates.yml` → `"24"` |
+| Python | `ci.yml` → `"3.12"`, audits → `"3.11"`, sem `.python-version` |
+| Postgres | `docker-compose` → `12`, CI → `16` |
+| Postgres porta | `docker-compose` → `5433`, CI/conftest/hb → `5432` |
+
+### Dependências
+
+Entregável 1 (enforcement unificado).
+
+### Arquivos a criar
+
+**`toolchain.json`** (raiz do repositório):
+
+```json
+{
+  "$schema": "./contracts/schemas/shared/toolchain.schema.json",
+  "version": "1.0.0",
+  "updated": "2026-04-02",
+  "runtimes": {
+    "node": "24",
+    "python": "3.12"
+  },
+  "services": {
+    "postgres": {
+      "image": "postgres:16",
+      "port": 5432,
+      "test_db": "hbtrack_test",
+      "test_user": "hbtrack",
+      "test_password": "testpassword"
+    },
+    "redis": {
+      "image": "redis:7-alpine",
+      "port": 6379
+    }
+  },
+  "tools": {
+    "oasdiff": "1.12.3"
+  }
+}
+```
+
+**`contracts/schemas/shared/toolchain.schema.json`** (validação formal):
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HB Track Toolchain Manifest",
+  "type": "object",
+  "required": ["version", "runtimes", "services", "tools"],
+  "properties": {
+    "version": { "type": "string" },
+    "updated": { "type": "string", "format": "date" },
+    "runtimes": {
+      "type": "object",
+      "required": ["node", "python"],
+      "properties": {
+        "node": { "type": "string" },
+        "python": { "type": "string" }
+      }
+    },
+    "services": {
+      "type": "object",
+      "required": ["postgres", "redis"],
+      "properties": {
+        "postgres": {
+          "type": "object",
+          "required": ["image", "port", "test_db", "test_user", "test_password"]
+        },
+        "redis": {
+          "type": "object",
+          "required": ["image", "port"]
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "required": ["oasdiff"]
+    }
+  }
+}
+```
+
+### Arquivos a alterar
+
+**1. `.nvmrc`** — alinhar com manifesto:
+
+```
+# Antes:
+v24.14.0
+
+# Depois — ler de toolchain.json não é possível em .nvmrc,
+# mas o valor deve ser consistente:
+24
+```
+
+> Nota: `.nvmrc` não suporta leitura dinâmica. O teste de invariante (criado no entregável 4) garante alinhamento.
+
+**2. `.github/workflows/ci.yml`** — 2 mudanças de Node version:
+
+```yaml
+# Linha 39 — Antes:
+          node-version: "22"
+# Depois:
+          node-version: "24"
+
+# Linha 158 — Antes:
+          node-version: "22"
+# Depois:
+          node-version: "24"
+```
+
+**3. `.github/workflows/context-efficiency-audit.yml`** — Python version:
+
+```yaml
+# Antes:
+          python-version: "3.11"
+# Depois:
+          python-version: "3.12"
+```
+
+**4. `.github/workflows/domain-completeness-audit.yml`** — Python version:
+
+```yaml
+# Antes:
+          python-version: "3.11"
+# Depois:
+          python-version: "3.12"
+```
+
+**5. `infra/docker-compose.yml`** — Postgres version e porta:
+
+```yaml
+# Antes:
+  postgres:
+    image: postgres:12
+    # ...
+    ports:
+      - "5433:5432"
+
+# Depois:
+  postgres:
+    image: postgres:16
+    # ...
+    ports:
+      - "5432:5432"
+```
+
+> Nota: a mudança de porta para `5432:5432` alinha com `conftest.py`, `hb preflight` e CI. Se houver outro serviço Postgres na máquina do dev, o teste de invariante avisa.
+
+**6. `infra/docker-compose.yml`** — credenciais de teste para Postgres:
+
+```yaml
+# Antes:
+    environment:
+      POSTGRES_DB: hb_track_dev
+      POSTGRES_USER: hbtrack_dev
+      POSTGRES_PASSWORD: hbtrack_dev_pwd
+
+# Depois — banco de dev continua, mas adicionar profile de teste:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-hb_track_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-hbtrack_dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-hbtrack_dev_pwd}
+```
+
+> A separação dev/test será completa quando Testcontainers entrar (entregável 5). Aqui o mínimo é alinhar versão e porta.
+
+### Critério de aceite
+
+- [ ] `toolchain.json` existe na raiz, passa validação contra `toolchain.schema.json`.
+- [ ] `grep -rn 'node-version' .github/workflows/` retorna apenas `"24"` em todos os workflows.
+- [ ] `grep -rn 'python-version' .github/workflows/` retorna apenas `"3.12"` em todos os workflows.
+- [ ] `infra/docker-compose.yml` usa `postgres:16` na porta `5432:5432`.
+- [ ] `.nvmrc` contém `24`.
+
+### Risco eliminado
+
+- Node 22 vs 24 vs v24.14.0 — **3 valores → 1**.
+- Python 3.11 vs 3.12 — **2 valores → 1**.
+- Postgres 12 vs 16 — **2 valores → 1**.
+- Porta 5433 vs 5432 — **2 valores → 1**.
+
+### Regra de autoridade do manifesto
+
+`toolchain.json` é SSOT. **Nenhum** arquivo pode declarar versão de runtime, serviço ou ferramenta fora dele.
+
+**Consumidores obrigatórios** (devem ler ou alinhar com o manifesto):
+
+| Consumidor | Como consome |
+|---|---|
+| `.github/workflows/*.yml` | Hardcoda o mesmo valor (validado por `test_toolchain_parity.py`) |
+| `.nvmrc` | Hardcoda o mesmo valor de `runtimes.node` |
+| `infra/docker-compose.yml` | Usa mesma image e porta de `services.postgres` e `services.redis` |
+| `scripts/hb` (`_ci_test_env`) | Lê `toolchain.json` em runtime (entregável 5) |
+| `scripts/bootstrap/dev_contract_env.sh` | Lê `toolchain.json` para oasdiff version |
+| `conftest.py` | Lê `toolchain.json` para Testcontainers config (entregável 5) |
+| `.github/workflows/_reusable-ci.yml` | Lê `toolchain.json` via `jq` (entregável 5) |
+
+**Proibição explícita**: qualquer script, workflow ou arquivo de configuração que instale ou configure Node, Python, Postgres, Redis, ou oasdiff **não pode** declarar versão inline. Deve consumir `toolchain.json` diretamente (via `jq`, `json.loads`, ou equivalente) **ou** ter o valor validado pelo teste de invariante `test_toolchain_parity.py`.
+
+> Enforcement: o teste de invariante (entregável 4) garante que essa regra é verificada automaticamente em cada `hb preflight` e em CI.
+
+### Validação de paridade
+
+```bash
+# Local:
+node --version   # deve começar com v24
+python3 --version  # deve ser 3.12.x
+docker compose -f infra/docker-compose.yml up -d postgres
+pg_isready -h localhost -p 5432  # deve responder OK
+```
+
+Comparar com CI: `grep` nos workflows confirma que os valores são idênticos ao manifesto.
+
+---
+
+## Entregável 3 — Manifesto canônico de merge-readiness
+
+### Problema que resolve
+
+Não existe declaração formal de quais checks bloqueiam merge, quais são informativos, e qual executor local reproduz cada um. O ruleset (entregável 1) configura isso no GitHub, mas sem rastreabilidade versionada. Se alguém alterar o ruleset pela UI, não há como detectar drift.
+
+### Dependências
+
+Entregável 1 (ruleset unificado) e entregável 2 (toolchain resolvido).
+
+### Arquivos a criar
+
+**`merge-readiness.json`** (raiz do repositório):
+
+```json
+{
+  "$schema": "./contracts/schemas/shared/merge-readiness.schema.json",
+  "version": "1.0.0",
+  "updated": "2026-04-02",
+  "target_branch": "main",
+  "ruleset_name": "contract-gates",
+  "ruleset_id": 13901517,
+  "checks": [
+    {
+      "context": "Validate Contract Gates",
+      "workflow": "contract-gates.yml",
+      "job": "validate-contracts",
+      "category": "required",
+      "local_equivalent": "python3 scripts/hb preflight (STEP 3)"
+    },
+    {
+      "context": "Governance Tests",
+      "workflow": "contract-gates.yml",
+      "job": "governance-tests",
+      "category": "required",
+      "local_equivalent": "pytest tests/test_pipeline_governance.py"
+    },
+    {
+      "context": "Architecture Drift Check",
+      "workflow": "contract-gates.yml",
+      "job": "architecture-drift-check",
+      "category": "required",
+      "local_equivalent": "python3 scripts/audit/check_architecture_docs.py --json && pytest tests/pipeline_gates/test_architecture_drift.py"
+    },
+    {
+      "context": "Adversarial Suite",
+      "workflow": "contract-gates.yml",
+      "job": "adversarial-suite",
+      "category": "required",
+      "local_equivalent": "pytest tests/adversarial -q"
+    },
+    {
+      "context": "CI / Validate Contracts",
+      "workflow": "ci.yml",
+      "job": "validate",
+      "category": "required",
+      "local_equivalent": "python3 scripts/hb preflight (STEP 3)"
+    },
+    {
+      "context": "CI / Tests",
+      "workflow": "ci.yml",
+      "job": "test",
+      "category": "required",
+      "local_equivalent": "python3 scripts/hb preflight (STEP 4)"
+    },
+    {
+      "context": "CI / Frontend Build + Tests",
+      "workflow": "ci.yml",
+      "job": "build-frontend",
+      "category": "required",
+      "local_equivalent": "python3 scripts/hb preflight (STEP 6)"
+    },
+    {
+      "context": "Docker Build Check",
+      "workflow": "ci.yml",
+      "job": "build",
+      "category": "informational",
+      "reason": "Valida Dockerfile mas não bloqueia merge"
+    },
+    {
+      "context": "Governance Enforcement (survival-suite)",
+      "workflow": "contract-gates.yml",
+      "job": "governance-enforcement",
+      "category": "conditional",
+      "condition": "governance_changed == true",
+      "reason": "Condicional — só roda em mudanças de governança"
+    },
+    {
+      "context": "Paridade Registry × Executor",
+      "workflow": "contract-gates.yml",
+      "job": "registry-executor-parity",
+      "category": "conditional",
+      "condition": "governance_changed == true",
+      "reason": "Condicional"
+    },
+    {
+      "context": "Paridade Schema × Template × Skills",
+      "workflow": "contract-gates.yml",
+      "job": "schema-template-skills-parity",
+      "category": "conditional",
+      "condition": "governance_changed == true",
+      "reason": "Condicional"
+    },
+    {
+      "context": "Validação Cruzada SESSION_HANDOFF ↔ session_start",
+      "workflow": "contract-gates.yml",
+      "job": "session-handoff-crossval",
+      "category": "conditional",
+      "condition": "governance_changed == true",
+      "reason": "Condicional"
+    }
+  ],
+  "enforcement": {
+    "require_pr": true,
+    "require_conversation_resolution": true,
+    "require_up_to_date": true,
+    "block_force_push": true,
+    "block_deletion": true,
+    "bypass_actors": []
+  },
+  "local_executor": {
+    "command": "python3 scripts/hb preflight",
+    "evidence_path": "_reports/preflight/latest.json",
+    "pre_push_hook": "scripts/git-hooks/pre-push"
+  }
+}
+```
+
+**`contracts/schemas/shared/merge-readiness.schema.json`**:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HB Track Merge-Readiness Manifest",
+  "type": "object",
+  "required": ["version", "target_branch", "ruleset_name", "checks", "enforcement", "local_executor"],
+  "properties": {
+    "version": { "type": "string" },
+    "target_branch": { "type": "string" },
+    "ruleset_name": { "type": "string" },
+    "ruleset_id": { "type": "integer" },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["context", "workflow", "job", "category"],
+        "properties": {
+          "context": { "type": "string" },
+          "workflow": { "type": "string" },
+          "job": { "type": "string" },
+          "category": {
+            "type": "string",
+            "enum": ["required", "informational", "conditional"],
+            "description": "required = bloqueia merge no ruleset. informational = roda mas não bloqueia. conditional = roda apenas quando condição de path-filter é true."
+          },
+          "local_equivalent": {
+            "type": "string",
+            "description": "Obrigatório para category=required. Comando local que reproduz este check."
+          },
+          "condition": {
+            "type": "string",
+            "description": "Obrigatório para category=conditional. Expressão que ativa o check."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Obrigatório para category=informational e conditional. Justificativa de não ser required."
+          }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "category": { "const": "required" } } },
+            "then": { "required": ["local_equivalent"] }
+          },
+          {
+            "if": { "properties": { "category": { "const": "conditional" } } },
+            "then": { "required": ["condition", "reason"] }
+          },
+          {
+            "if": { "properties": { "category": { "const": "informational" } } },
+            "then": { "required": ["reason"] }
+          }
+        ]
+      }
+    },
+    "enforcement": {
+      "type": "object",
+      "required": ["require_pr", "require_conversation_resolution", "block_force_push", "bypass_actors"]
+    },
+    "local_executor": {
+      "type": "object",
+      "required": ["command", "evidence_path"]
+    }
+  }
+}
+```
+
+> **Taxonomia formal**: o campo `category` é um enum restrito. Cada categoria exige campos diferentes (`local_equivalent` para required, `condition`+`reason` para conditional, `reason` para informational). O schema valida isso via `allOf`/`if`/`then`.
+
+### Critério de aceite
+
+- [ ] `merge-readiness.json` existe na raiz, passa validação contra o schema (incluindo `allOf`/`if`/`then`).
+- [ ] Todo check com `"category": "required"` tem `local_equivalent` preenchido.
+- [ ] Todo check com `"category": "conditional"` tem `condition` e `reason` preenchidos.
+- [ ] A lista de checks com `"category": "required"` tem exatamente os mesmos contexts que o ruleset retornado pela API.
+- [ ] `jq '[.checks[] | select(.category == "required")] | length' merge-readiness.json` retorna `7`.
+
+### Risco eliminado
+
+- Drift silencioso entre ruleset no GitHub e expectativa do time.
+- Impossibilidade de auditar a política de merge sem acesso admin ao GitHub.
+- Falta de mapeamento entre check CI e comando local equivalente.
+
+### Validação de paridade
+
+```bash
+# Script de verificação (criado no entregável 4):
+# Compara merge-readiness.json com o ruleset real via API.
+# Se divergir, falha.
+```
+
+---
+
+## Entregável 4 — actionlint + políticas mínimas de integridade estrutural
+
+### Problema que resolve
+
+Hoje não existe nenhuma proteção contra:
+- Erro de sintaxe/semântica em workflows (ex: `scripts/validate_contracts.py` em `contract-gates.yml` — path errado, deveria ser `scripts/contracts/validate/validate_contracts.py`).
+- Drift de versão entre `toolchain.json` e os workflows/docker-compose/bootstrap.
+- Drift entre `merge-readiness.json` e o ruleset real no GitHub.
+
+### Dependências
+
+Entregáveis 2 e 3 (manifestos existem).
+
+### Arquivos a criar
+
+**`tests/invariants/test_toolchain_parity.py`**:
+
+```python
+"""
+Testa que todas as fontes de versão consomem o manifesto toolchain.json.
+Falha se qualquer arquivo usar versão diferente da canônica.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOLCHAIN = json.loads((ROOT / "toolchain.json").read_text())
+
+
+def _grep_yaml_value(filepath: Path, key: str) -> list[str]:
+    """Extrai valores associados a uma chave em YAML."""
+    content = filepath.read_text()
+    return re.findall(rf'{key}:\s*["\']?(\S+?)["\']?\s*$', content, re.MULTILINE)
+
+
+class TestNodeVersion:
+    expected = TOOLCHAIN["runtimes"]["node"]
+
+    def test_nvmrc(self):
+        nvmrc = (ROOT / ".nvmrc").read_text().strip()
+        assert nvmrc == self.expected, f".nvmrc={nvmrc}, expected={self.expected}"
+
+    @pytest.mark.parametrize("wf", list((ROOT / ".github/workflows").glob("*.yml")))
+    def test_workflow_node_version(self, wf):
+        versions = _grep_yaml_value(wf, "node-version")
+        for v in versions:
+            assert v == self.expected, f"{wf.name} has node-version={v}, expected={self.expected}"
+
+
+class TestPythonVersion:
+    expected = TOOLCHAIN["runtimes"]["python"]
+
+    @pytest.mark.parametrize("wf", list((ROOT / ".github/workflows").glob("*.yml")))
+    def test_workflow_python_version(self, wf):
+        versions = _grep_yaml_value(wf, "python-version")
+        for v in versions:
+            assert v == self.expected, f"{wf.name} has python-version={v}, expected={self.expected}"
+
+
+class TestPostgresVersion:
+    pg = TOOLCHAIN["services"]["postgres"]
+
+    def test_docker_compose(self):
+        dc = (ROOT / "infra/docker-compose.yml").read_text()
+        assert self.pg["image"] in dc, f"docker-compose missing {self.pg['image']}"
+
+    def test_ci_services(self):
+        ci = (ROOT / ".github/workflows/ci.yml").read_text()
+        assert self.pg["image"] in ci, f"ci.yml missing {self.pg['image']}"
+
+    def test_port_in_docker_compose(self):
+        dc = (ROOT / "infra/docker-compose.yml").read_text()
+        expected_port = str(self.pg["port"])
+        assert f'"{expected_port}:{expected_port}"' in dc or f"'{expected_port}:{expected_port}'" in dc
+
+
+class TestOasdiffVersion:
+    expected = TOOLCHAIN["tools"]["oasdiff"]
+
+    @pytest.mark.parametrize("wf", list((ROOT / ".github/workflows").glob("*.yml")))
+    def test_workflow_oasdiff_version(self, wf):
+        content = wf.read_text()
+        if "oasdiff" not in content:
+            pytest.skip(f"{wf.name} does not use oasdiff")
+        versions = re.findall(r'oasdiff[/_](\d+\.\d+\.\d+)', content)
+        for v in versions:
+            assert v == self.expected, f"{wf.name} has oasdiff={v}, expected={self.expected}"
+```
+
+**`tests/invariants/test_merge_readiness_parity.py`**:
+
+```python
+"""
+Testa que merge-readiness.json está em sincronia com as definições locais.
+A verificação contra o ruleset real no GitHub é feita por um script separado
+(requer token — não roda em todo pytest local).
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_merge_readiness_schema():
+    manifest = json.loads((ROOT / "merge-readiness.json").read_text())
+    schema = json.loads(
+        (ROOT / "contracts/schemas/shared/merge-readiness.schema.json").read_text()
+    )
+    import jsonschema
+    jsonschema.validate(manifest, schema)
+
+
+def test_toolchain_schema():
+    manifest = json.loads((ROOT / "toolchain.json").read_text())
+    schema = json.loads(
+        (ROOT / "contracts/schemas/shared/toolchain.schema.json").read_text()
+    )
+    import jsonschema
+    jsonschema.validate(manifest, schema)
+
+
+def test_required_checks_have_local_equivalent():
+    manifest = json.loads((ROOT / "merge-readiness.json").read_text())
+    for check in manifest["checks"]:
+        if check["category"] == "required":
+            assert check.get("local_equivalent"), (
+                f"Check '{check['context']}' é required mas não tem local_equivalent"
+            )
+
+
+def test_conditional_checks_have_condition():
+    manifest = json.loads((ROOT / "merge-readiness.json").read_text())
+    for check in manifest["checks"]:
+        if check["category"] == "conditional":
+            assert check.get("condition"), (
+                f"Check '{check['context']}' é conditional mas não tem condition"
+            )
+            assert check.get("reason"), (
+                f"Check '{check['context']}' é conditional mas não tem reason"
+            )
+
+
+def test_all_required_check_workflows_exist():
+    manifest = json.loads((ROOT / "merge-readiness.json").read_text())
+    wf_dir = ROOT / ".github/workflows"
+    for check in manifest["checks"]:
+        wf = wf_dir / check["workflow"]
+        assert wf.exists(), f"Workflow '{check['workflow']}' referenciado mas não existe"
+
+
+def test_category_values_are_valid():
+    manifest = json.loads((ROOT / "merge-readiness.json").read_text())
+    valid = {"required", "informational", "conditional"}
+    for check in manifest["checks"]:
+        assert check["category"] in valid, (
+            f"Check '{check['context']}' tem category='{check['category']}', válidos: {valid}"
+        )
+```
+
+### Arquivos a alterar
+
+**1. Corrigir `contract-gates.yml` — path errado do validate_contracts:**
+
+```yaml
+# Linha ~110 — Antes:
+          python3 scripts/validate_contracts.py
+# Depois:
+          python3 scripts/contracts/validate/validate_contracts.py
+```
+
+**2. Adicionar actionlint ao CI — novo job em `contract-gates.yml`:**
+
+```yaml
+  # Adicionar como primeiro job (sem dependências):
+  lint-workflows:
+    name: Lint Workflows (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+```
+
+**3. Adicionar testes de invariante ao `hb preflight` — alterar `scripts/hb`:**
+
+Na seção `_preflight_step_test_suites`, adicionar `tests/invariants` como uma das suítes:
+
+```python
+# Adicionar à lista de suítes em _preflight_step_test_suites:
+("invariants", [str(self.root / "tests/invariants"), "-v"]),
+```
+
+**4. Adicionar actionlint ao pre-commit ou pre-push local:**
+
+Instalar `actionlint` no bootstrap e executar em `hb preflight` STEP 1 (toolchain):
+
+```python
+# No _preflight_step_toolchain, adicionar verificação:
+# actionlint (se disponível)
+if shutil.which("actionlint"):
+    result = subprocess.run(
+        ["actionlint"],
+        capture_output=True, text=True, cwd=self.root,
+    )
+    if result.returncode != 0:
+        print(f"❌ actionlint found issues:\n{result.stdout}{result.stderr}")
+        return False
+```
+
+### Critério de aceite
+
+- [ ] `actionlint` roda em CI (job `lint-workflows` verde).
+- [ ] `contract-gates.yml` chama path correto (`scripts/contracts/validate/validate_contracts.py`).
+- [ ] `pytest tests/invariants/ -v` passa localmente.
+- [ ] Se alguém mudar `node-version: "22"` em qualquer workflow, `test_toolchain_parity.py` falha.
+- [ ] `hb preflight` inclui suíte de invariantes.
+
+### Risco eliminado
+
+- Workflow com sintaxe/semântica inválida passa para `main` (path errado já existe hoje).
+- Drift de versão entre manifesto e consumidores passa despercebido.
+- Manifesto de merge-readiness diverge dos workflows reais.
+
+### Validação de paridade
+
+```bash
+# Rodar localmente:
+pytest tests/invariants/ -v
+
+# Rodar no GitHub:
+# Job lint-workflows + testes de invariante incluídos nas suítes.
+# Se ambos passam, as fontes de versão estão alinhadas.
+```
+
+---
+
+## Entregável 5 — Executor canônico + reusable workflow + Testcontainers
+
+### Problema que resolve
+
+Hoje os workflows repetem inline toda a lógica de bootstrap (pip install, npm ci, oasdiff download, etc.) e os testes dependem de `services:` no GitHub e `docker-compose` local — dois mecanismos diferentes para subir Postgres/Redis.
+
+### Dependências
+
+Entregáveis 2, 3 e 4 (manifesto de toolchain, merge-readiness e testes de invariante existem).
+
+### Arquivos a criar
+
+**1. `.github/workflows/_reusable-ci.yml`** — reusable workflow:
+
+```yaml
+name: Reusable CI
+
+on:
+  workflow_call:
+    inputs:
+      profile:
+        description: "Executor profile: pr | contract-gates | full"
+        required: true
+        type: string
+
+jobs:
+  setup-and-run:
+    name: "CI [${{ inputs.profile }}]"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read toolchain manifest
+        id: toolchain
+        run: |
+          echo "node=$(jq -r .runtimes.node toolchain.json)" >> "$GITHUB_OUTPUT"
+          echo "python=$(jq -r .runtimes.python toolchain.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ steps.toolchain.outputs.node }}"
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ steps.toolchain.outputs.python }}"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt -r requirements-dev.txt -r scripts/_policy/requirements.txt
+          npm ci
+
+      - name: Install oasdiff
+        run: |
+          VERSION=$(jq -r .tools.oasdiff toolchain.json)
+          curl -fsSL "https://github.com/oasdiff/oasdiff/releases/download/v${VERSION}/oasdiff_${VERSION}_linux_amd64.tar.gz" \
+            -o "$RUNNER_TEMP/oasdiff.tar.gz"
+          tar -xzf "$RUNNER_TEMP/oasdiff.tar.gz" -C "$RUNNER_TEMP"
+          install -m 0755 "$RUNNER_TEMP/oasdiff" "$RUNNER_TEMP/oasdiff-bin"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: Configure git hooks path
+        run: git config core.hooksPath scripts/git-hooks
+
+      - name: Run executor
+        run: python3 scripts/hb ci --profile "${{ inputs.profile }}"
+        env:
+          CI: "true"
+```
+
+> Nota: o reusable workflow lê versões do `toolchain.json`. Nunca hardcoda.
+
+**2. `conftest.py`** — adicionar Testcontainers fixtures:
+
+Adicionar ao `requirements-dev.txt`:
+```
+testcontainers[postgres,redis]==4.10.0
+```
+
+Alterar `conftest.py` para usar Testcontainers quando disponível:
+
+```python
+# Substituir _postgres_available() e django_db_setup() por:
+
+def _postgres_available() -> bool:
+    """Check if Postgres is reachable at configured host:port."""
+    host = os.environ.get("DB_HOST", "localhost")
+    port = int(os.environ.get("DB_PORT", "5432"))
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(1)
+        s.connect((host, port))
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(scope="session")
+def _testcontainers_postgres():
+    """Start Postgres via Testcontainers if no external Postgres available."""
+    if _postgres_available():
+        yield  # Use external Postgres (CI services: or local docker-compose)
+        return
+
+    try:
+        import json as _json
+        from testcontainers.postgres import PostgresContainer
+
+        toolchain = _json.loads((_ROOT / "toolchain.json").read_text())
+        pg = toolchain["services"]["postgres"]
+
+        with PostgresContainer(
+            image=pg["image"],
+            username=pg["test_user"],
+            password=pg["test_password"],
+            dbname=pg["test_db"],
+            port=pg["port"],
+        ) as postgres:
+            host = postgres.get_container_host_ip()
+            port = postgres.get_exposed_port(pg["port"])
+            os.environ["DB_HOST"] = host
+            os.environ["DB_PORT"] = str(port)
+            os.environ["DB_NAME"] = pg["test_db"]
+            os.environ["DB_USER"] = pg["test_user"]
+            os.environ["DB_PASSWORD"] = pg["test_password"]
+            os.environ["DATABASE_URL"] = (
+                f"postgres://{pg['test_user']}:{pg['test_password']}"
+                f"@{host}:{port}/{pg['test_db']}"
+            )
+            yield
+    except ImportError:
+        pytest.skip("testcontainers not installed and no external Postgres")
+
+
+@pytest.fixture(scope="session")
+def _testcontainers_redis():
+    """Start Redis via Testcontainers if no external Redis available."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(1)
+        s.connect(("localhost", 6379))
+        s.close()
+        yield
+        return
+    except OSError:
+        pass
+
+    try:
+        import json as _json
+        from testcontainers.redis import RedisContainer
+
+        toolchain = _json.loads((_ROOT / "toolchain.json").read_text())
+        redis_cfg = toolchain["services"]["redis"]
+
+        with RedisContainer(image=redis_cfg["image"]) as redis:
+            host = redis.get_container_host_ip()
+            port = redis.get_exposed_port(redis_cfg["port"])
+            os.environ["REDIS_URL"] = f"redis://{host}:{port}/0"
+            os.environ["CELERY_BROKER_URL"] = f"redis://{host}:{port}/1"
+            os.environ["CELERY_RESULT_BACKEND"] = f"redis://{host}:{port}/2"
+            yield
+    except ImportError:
+        pytest.skip("testcontainers not installed and no external Redis")
+
+
+@pytest.fixture(scope="session")
+def django_db_setup(_testcontainers_postgres):
+    """Override pytest-django database setup.
+    Uses Testcontainers if no external Postgres available.
+    """
+    if not _postgres_available():
+        pytest.skip("PostgreSQL não disponível e Testcontainers não instalado.")
+```
+
+### Roadmap de convergência para caminho único de teste
+
+O `conftest.py` acima é **Phase 1 (híbrida)**: aceita Postgres externo ou Testcontainers. Isso é pragmático para a transição, mas mantém dois caminhos possíveis.
+
+**Phase 2 (caminho único — Testcontainers only):**
+
+| Quando | O que | Resultado |
+|---|---|---|
+| Entregável 5 (este) | Implementar `conftest.py` híbrido | Dev pode rodar testes sem `docker-compose up` |
+| Pós-entregável 6 (prova verde) | Remover `services:` dos workflows CI (substituir por Testcontainers no runner) | CI e local usam o mesmo mecanismo |
+| Após estabilização | Remover fallback para Postgres externo do `conftest.py` | Um único caminho oficial: Testcontainers |
+| Após estabilização | Mover `infra/docker-compose.yml` para uso exclusivo de dev (app local, não testes) | `docker-compose` deixa de ser relevante para testes |
+
+**Critério para entrar em Phase 2**: entregável 6 (prova operacional) verde. Ou seja, a transição para caminho único **não bloqueia** este plano — é evolução natural pós-paridade.
+
+> Enquanto houver "às vezes usa externo, às vezes usa container", ainda existe superfície de divergência residual. A Phase 2 elimina isso por completo.
+
+**3. `scripts/hb`** — adicionar subcomando `ci --profile`:
+
+```python
+def cmd_ci(self, profile: str = "full") -> int:
+    """Executor canônico de CI — chamado por reusable workflow e hb preflight."""
+    profiles = {
+        "pr": ["validate", "test", "frontend", "invariants"],
+        "contract-gates": ["validate", "compilers", "governance", "adversarial", "architecture", "invariants"],
+        "full": ["validate", "test", "frontend", "compilers", "governance", "adversarial", "architecture", "docker", "invariants"],
+    }
+    steps = profiles.get(profile)
+    if not steps:
+        print(f"❌ Profile desconhecido: {profile}. Válidos: {', '.join(profiles)}")
+        return 1
+    # ... executar cada step
+```
+
+### Arquivos a alterar
+
+**1. `.github/workflows/ci.yml`** — transformar em caller fino:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/_reusable-ci.yml
+    with:
+      profile: pr
+```
+
+> Nota: os job names reportados ao GitHub mudam. O entregável 1 (ruleset) precisa ser atualizado para refletir os novos nomes de check. Fazer isso atomicamente neste entregável.
+
+**2. `.github/workflows/contract-gates.yml`** — jobs incondicionais viram callers:
+
+Os jobs `validate-contracts`, `governance-tests`, `adversarial-suite`, `architecture-drift-check` podem ser consolidados no reusable workflow com `profile: contract-gates`. Os jobs condicionais (`governance-enforcement`, etc.) permanecem inline porque dependem de path filtering.
+
+**3. `requirements-dev.txt`** — adicionar testcontainers:
+
+```
+testcontainers[postgres,redis]==4.10.0
+```
+
+**4. `scripts/hb` `_CI_TEST_ENV`** — ler do manifesto em vez de hardcodar:
+
+```python
+@property
+def _ci_test_env(self) -> dict[str, str]:
+    """Build CI test env from toolchain.json."""
+    tc = json.loads((self.root / "toolchain.json").read_text())
+    pg = tc["services"]["postgres"]
+    redis_port = tc["services"]["redis"]["port"]
+    return {
+        "CI": "true",
+        "SECRET_KEY": "ci-secret-key-for-testing-only-not-real",
+        "DEBUG": "false",
+        "ALLOWED_HOSTS": "localhost,127.0.0.1",
+        "HB_RUN_SCHEMATHESIS": "1",
+        "HB_SCHEMATHESIS_MAX_EXAMPLES": "10",
+        "DATABASE_URL": f"postgres://{pg['test_user']}:{pg['test_password']}@localhost:{pg['port']}/{pg['test_db']}",
+        "DB_NAME": pg["test_db"],
+        "DB_USER": pg["test_user"],
+        "DB_PASSWORD": pg["test_password"],
+        "DB_HOST": "localhost",
+        "DB_PORT": str(pg["port"]),
+        "REDIS_URL": f"redis://localhost:{redis_port}/0",
+        "CELERY_BROKER_URL": f"redis://localhost:{redis_port}/1",
+        "CELERY_RESULT_BACKEND": f"redis://localhost:{redis_port}/2",
+        "CORS_ALLOWED_ORIGINS": "http://localhost:3000,http://localhost:5173",
+        "LOG_LEVEL": "WARNING",
+        "JWT_ALGORITHM": "HS256",
+        "JWT_SECRET": "ci-jwt-secret-for-testing-only",
+    }
+```
+
+### Critério de aceite
+
+- [ ] `ci.yml` tem menos de 30 linhas e chama `_reusable-ci.yml`.
+- [ ] `_reusable-ci.yml` lê versões de `toolchain.json` (nunca hardcoda).
+- [ ] `pytest` local sem `docker-compose up` sobe Postgres/Redis via Testcontainers automaticamente.
+- [ ] `hb preflight` usa `_ci_test_env` derivado de `toolchain.json`.
+- [ ] `scripts/hb ci --profile pr` reproduz o mesmo caminho que o reusable workflow.
+
+### Risco eliminado
+
+- Duplicação de lógica de bootstrap entre 5 workflows.
+- Dependência de `docker-compose` ou `services:` para rodar testes.
+- Hardcode de versões/portas/credenciais em `_CI_TEST_ENV`.
+- Divergência entre o que roda local e o que roda no GitHub.
+
+### Validação de paridade (prova operacional definitiva)
+
+```bash
+# 1. Rodar local:
+python3 scripts/hb preflight
+# Resultado: PASS, evidence gerada em _reports/preflight/latest.json
+
+# 2. Push:
+git push
+
+# 3. Esperar CI:
+# Todos os required checks (7) devem ficar verdes.
+
+# 4. Comparar:
+# Se PASS local + PASS CI no mesmo SHA → paridade confirmada.
+```
+
+---
+
+## Entregável 6 — Prova operacional definitiva
+
+### Problema que resolve
+
+Os entregáveis 1–5 implementam a solução. Mas **implementar ≠ resolver**. O plano não está encerrado até que haja comprovação empírica de paridade end-to-end. Sem este entregável, os 5 anteriores são infraestrutura sem validação de resultado.
+
+### Dependências
+
+Entregáveis 1–5 implementados e commitados.
+
+### Protocolo de execução
+
+**Passo 1 — Executar preflight local:**
+
+```bash
+python3 scripts/hb preflight
+```
+
+Resultado esperado: `verdict: PASS` em `_reports/preflight/latest.json`.
+
+**Passo 2 — Registrar SHA e evidência:**
+
+```bash
+SHA=$(git rev-parse HEAD)
+echo "SHA testado: $SHA"
+cat _reports/preflight/latest.json | jq '{sha, verdict, timestamp, steps}'
+```
+
+**Passo 3 — Push:**
+
+```bash
+git push
+```
+
+O pre-push hook valida que o SHA local tem evidence PASS recente (< 60 min).
+
+**Passo 4 — Aguardar CI no GitHub:**
+
+Todos os 7 required checks devem ficar verdes para o mesmo SHA.
+
+**Passo 5 — Comparar e registrar:**
+
+```bash
+# Buscar status de checks para o SHA:
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/hbtrack/official/commits/$SHA/check-runs" \
+  | jq '[.check_runs[] | {name, conclusion}]'
+```
+
+**Passo 6 — Registrar evidência final:**
+
+Criar `_reports/parity/proof_$(date +%Y%m%d).json`:
+
+```json
+{
+  "sha": "<SHA>",
+  "date": "2026-04-XX",
+  "preflight_local": "PASS",
+  "preflight_evidence": "_reports/preflight/latest.json",
+  "ci_checks": {
+    "Validate Contract Gates": "success",
+    "Governance Tests": "success",
+    "Architecture Drift Check": "success",
+    "Adversarial Suite": "success",
+    "CI / Validate Contracts": "success",
+    "CI / Tests": "success",
+    "CI / Frontend Build + Tests": "success"
+  },
+  "parity_confirmed": true,
+  "verdict": "PARIDADE_CONFIRMADA"
+}
+```
+
+### Critério de aceite
+
+- [ ] `hb preflight` retorna PASS com evidence.
+- [ ] `git push` aceito pelo pre-push hook.
+- [ ] 7/7 required checks verdes no GitHub para o mesmo SHA.
+- [ ] Evidência registrada em `_reports/parity/`.
+- [ ] Nenhum check informational ou conditional está vermelho (podem estar skipped, mas não failed).
+
+### Risco eliminado
+
+- Falsa sensação de conclusão sem validação empírica.
+- Resultado "funciona na minha máquina mas não no CI" ou vice-versa.
+
+### O que acontece se falhar
+
+Se algum check falhar neste ponto:
+
+1. O problema residual está **documentado** — os testes de invariante e manifestos indicam exatamente o que diverge.
+2. Voltar ao entregável correspondente e corrigir.
+3. Repetir entregável 6 até verde.
+
+> **Este entregável é o critério de encerramento do problema.** O plano não está concluído até que este entregável passe.
+
+---
+
+## Resumo de arquivos
+
+### Arquivos a criar (8)
+
+| Arquivo | Entregável |
+|---|---|
+| `toolchain.json` | 2 |
+| `contracts/schemas/shared/toolchain.schema.json` | 2 |
+| `merge-readiness.json` | 3 |
+| `contracts/schemas/shared/merge-readiness.schema.json` | 3 |
+| `tests/invariants/test_toolchain_parity.py` | 4 |
+| `tests/invariants/test_merge_readiness_parity.py` | 4 |
+| `.github/workflows/_reusable-ci.yml` | 5 |
+| `tests/invariants/__init__.py` | 4 |
+
+### Evidências geradas (não versionadas, mas registradas)
+
+| Arquivo | Entregável | Status |
+|---|---|---|
+| `_reports/enforcement/branch_protection_snapshot_20260403.json` | 1 | ✅ gerado |
+| `_reports/enforcement/ruleset_snapshot_20260403.json` | 1 | ✅ gerado |
+| `_reports/enforcement/ruleset_snapshot_after.json` | 1 | ✅ gerado |
+| `_reports/enforcement/ruleset_update_response.json` | 1 | ✅ gerado |
+| `_reports/enforcement/ruleset_fix_adversarial.json` | 1 | ✅ gerado |
+| `_reports/enforcement/branch_protection_delete_response.json` | 1 | ✅ gerado |
+| `_reports/parity/proof_*.json` | 6 | ⏳ pendente |
+
+### Arquivos a alterar (11)
+
+| Arquivo | Entregáveis | Mudança |
+|---|---|---|
+| `.nvmrc` | 2 | `v24.14.0` → `24` |
+| `.github/workflows/ci.yml` | 2, 5 | Node 22→24, depois caller fino |
+| `.github/workflows/contract-gates.yml` | 4, 5 | Fix path, add actionlint job, consolidar jobs |
+| `.github/workflows/context-efficiency-audit.yml` | 2 | Python 3.11→3.12 |
+| `.github/workflows/domain-completeness-audit.yml` | 2 | Python 3.11→3.12 |
+| `infra/docker-compose.yml` | 2 | Postgres 12→16, porta 5433→5432 |
+| `conftest.py` | 5 | Testcontainers fixtures |
+| `scripts/hb` | 4, 5 | Invariants suite, `ci` subcommand, `_ci_test_env` from manifest |
+| `requirements-dev.txt` | 5 | Adicionar testcontainers |
+| `scripts/bootstrap/dev_contract_env.sh` | 4 | Instalar actionlint |
+| `package.json` | — | Sem mudança (engines não adicionado; manifesto + teste de invariante é suficiente) |
+
+### Ações no GitHub (não versionadas)
+
+| Ação | Entregável | Status |
+|---|---|---|
+| Exportar snapshots de branch protection e ruleset | 1 | ✅ 2026-04-03 |
+| Atualizar ruleset `contract-gates` com 6 checks (5→6; +`CI/Frontend Build + Tests`) | 1 | ✅ 2026-04-03 |
+| Remover `Adversarial Suite` do ruleset (job inexistente) | 1 | ✅ 2026-04-03 |
+| Validar ruleset via API | 1 | ✅ 2026-04-03 |
+| Remover branch protection da `main` (após validação) | 1 | ✅ 2026-04-03 (404 confirmado) |
+| Re-adicionar `Adversarial Suite` ao ruleset | 4 | ⏳ após criação do job |
+| Atualizar ruleset após renomear checks (caller fino) | 5 | ⏳ pendente |
+| Coletar check-runs do SHA e registrar prova | 6 | ⏳ pendente |
+
+---
+
+## Grafo de dependências
+
+```
+Entregável 1 (enforcement)
+    └── Entregável 2 (toolchain)
+            └── Entregável 3 (merge-readiness)
+                    └── Entregável 4 (actionlint + invariantes)
+                            └── Entregável 5 (executor + reusable + testcontainers)
+                                    └── Entregável 6 (prova operacional)
+```
+
+Cada entregável 1–5 é independentemente commitável e mergeável. A sequência garante que nenhum entregável posterior depende de estrutura que ainda não existe. O entregável 6 é a validação final — roda após todos os anteriores estarem na `main`.
+
+## Critério de encerramento do problema
+
+O problema de paridade local × CI está **encerrado** quando, e somente quando:
+
+1. Os 6 entregáveis estiverem implementados; — ⏳ E1 ✅ | E2–E6 pendentes
+2. Os testes de invariante estiverem verdes;
+3. O ruleset estiver correto e único; — ⏳ parcial (6 checks ✅; `Adversarial Suite` pendente PR-4)
+4. `hb preflight` passar de ponta a ponta;
+5. O mesmo SHA for enviado ao GitHub;
+6. Os 7 required checks ficarem verdes;
+7. A evidência final estiver registrada em `_reports/parity/`.
+
+Qualquer condição faltando = problema aberto.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,28 +1,29 @@
 ---
-data_ultima_sessao: "2026-03-31"
-branch_ativo: parity/toolchain-manifest
+data_ultima_sessao: "2026-04-03"
+branch_ativo: main
 modo_operacao: ROADMAP
-ci_status: UNKNOWN
-modulo_foco: training
+ci_status: GREEN
+modulo_foco: parity
 fase_roadmap: 5
 task_type: execute_roadmap_phase
 boot_profile_id: roadmap_execution
-task_id: roadmap-fase5-frontend-ciclo1
-resultado: DONE
-proxima_acao_permitida: "Iniciar FASE 5 Frontend Ciclo 1 (React + openapi-typescript)."
+task_id: parity-enforcement-toolchain
+resultado: IN_PROGRESS
+proxima_acao_permitida: "Iniciar PR-3 (merge-readiness manifest) do PLAN_EXEC_PARIDADE.md."
 bloqueios_ativos: []
 evidence_paths:
-  - ROADMAP.md
-  - .github/workflows/ci.yml
-  - scripts/hb
-  - _reports/contract_gates/precommit.latest.json
+  - PLAN_EXEC_PARIDADE.md
+  - PLAN_PARIEDADE.md
+  - toolchain.json
+  - contracts/schemas/shared/toolchain.schema.json
+  - docs/_canon/RUNTIME_CURRENT_STATE.md
 ---
 # SESSION HANDOFF — HB TRACK
 > Delta-only. Histórico em `_archive/SESSION_HANDOFF_PRE_FASE0_20260323.md`
 
 ## Estado Geral
-**Data:** 2026-03-31 | **Branch:** main | **CI:** 🟢 GREEN (12/12 ✓)
-**Modo:** ROADMAP | **Fase:** 5 | **Resultado:** FASE 4 CONCLUÍDA
+**Data:** 2026-04-03 | **Branch:** main | **CI:** 🟢 GREEN (12/12 ✓)
+**Modo:** ROADMAP | **Fase:** Paridade | **Resultado:** PR-1 + PR-2 MERGEADOS
 
 ## O que foi feito nesta sessão (FASE 4 closure)
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -13,10 +13,11 @@ proxima_acao_permitida: "Iniciar PR-3 (merge-readiness manifest) do PLAN_EXEC_PA
 bloqueios_ativos: []
 evidence_paths:
   - PLAN_EXEC_PARIDADE.md
-  - PLAN_PARIEDADE.md
   - toolchain.json
   - contracts/schemas/shared/toolchain.schema.json
   - docs/_canon/RUNTIME_CURRENT_STATE.md
+  - merge-readiness.json
+  - contracts/schemas/shared/merge-readiness.schema.json
 ---
 # SESSION HANDOFF — HB TRACK
 > Delta-only. Histórico em `_archive/SESSION_HANDOFF_PRE_FASE0_20260323.md`

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,14 +1,14 @@
 ---
 data_ultima_sessao: "2026-04-03"
-branch_ativo: main
+branch_ativo: parity/merge-readiness
 modo_operacao: ROADMAP
-ci_status: GREEN
+ci_status: UNKNOWN
 modulo_foco: parity
 fase_roadmap: 5
 task_type: execute_roadmap_phase
 boot_profile_id: roadmap_execution
 task_id: parity-enforcement-toolchain
-resultado: IN_PROGRESS
+resultado: PENDENTE
 proxima_acao_permitida: "Iniciar PR-3 (merge-readiness manifest) do PLAN_EXEC_PARIDADE.md."
 bloqueios_ativos: []
 evidence_paths:

--- a/_reports/contract_gates/local.latest.json
+++ b/_reports/contract_gates/local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-03-27T23:02:17Z",
+  "timestamp_utc": "2026-04-03T05:45:29Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "1b6ac5a",
+    "git_commit": "7c45aec9",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -17,7 +17,7 @@
       "oasdiff": "oasdiff version 1.12.3",
       "schemathesis": "schemathesis, version 4.12.1",
       "json_schema_validator": null,
-      "asyncapi_validator": "@asyncapi/cli/6.0.0 wsl-x64 node-v24.14.0",
+      "asyncapi_validator": "@asyncapi/cli/6.0.0 wsl-x64 node-v24.14.1",
       "arazzo_validator": null,
       "storybook": null
     }
@@ -31,11 +31,11 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260327T230217_95cbe5"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260403T054529_d21ac7"
   },
   "status_detail": {
-    "active_gates_passed": 23,
-    "skip_count": 30,
+    "active_gates_passed": 27,
+    "skip_count": 26,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -107,11 +107,11 @@
       },
       {
         "gate_id": "REF_HERMETICITY_GATE",
-        "status": "SKIP_NOT_APPLICABLE"
+        "status": "PASS"
       },
       {
         "gate_id": "TOOLING_CONFIG_GATE",
-        "status": "SKIP_NOT_APPLICABLE"
+        "status": "PASS"
       },
       {
         "gate_id": "OPENAPI_ROOT_STRUCTURE_GATE",
@@ -123,7 +123,7 @@
       },
       {
         "gate_id": "OPENAPI_POLICY_RULESET_GATE",
-        "status": "SKIP_NOT_APPLICABLE"
+        "status": "PASS"
       },
       {
         "gate_id": "JSON_SCHEMA_VALIDATION_GATE",
@@ -159,7 +159,7 @@
       },
       {
         "gate_id": "ARAZZO_COMPLETENESS_GATE",
-        "status": "SKIP_NOT_APPLICABLE"
+        "status": "PASS"
       },
       {
         "gate_id": "UI_DOC_VALIDATION_GATE",
@@ -229,7 +229,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 159
+        "duration_ms": 147
       }
     },
     {
@@ -254,7 +254,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4109
+        "duration_ms": 5363
       }
     },
     {
@@ -365,7 +365,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 16
+        "duration_ms": 25
       }
     },
     {
@@ -518,7 +518,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 130
+        "duration_ms": 189
       }
     },
     {
@@ -615,7 +615,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 10
       }
     },
     {
@@ -624,7 +624,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Nenhum token placeholder em 351 arquivo(s) verificado(s).",
+      "summary": "Nenhum token placeholder em 353 arquivo(s) verificado(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/_waivers/CONTRACT_BREAKING_CHANGE_GATE/README.md",
@@ -926,12 +926,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/toolchain.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/waiver.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/teams/team.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/training/athlete_chat_conversation.schema.json",
@@ -985,43 +987,116 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 74
+        "duration_ms": 117
       }
     },
     {
       "gate_id": "REF_HERMETICITY_GATE",
-      "status": "SKIP_NOT_APPLICABLE",
+      "status": "PASS",
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Pulado no perfil 'local'.",
+      "summary": "Todos os $refs herméticos (67 arquivo(s)).",
       "inputs": [],
-      "artifacts_checked": [],
+      "artifacts_checked": [
+        "/home/davis/HB-TRACK/contracts/openapi/components/parameters/page.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/parameters/pageSize.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/parameters/pageToken.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/ai_ingestion/ingestion_job.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/analytics/analytics_metric_key.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/analytics/analytics_query_request.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/analytics/analytics_query_response.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/analytics/analytics_snapshot.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/audit/audit_entry.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/common/error.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/competitions/competition.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/exercises/exercise.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/exercises/exercise_preview.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/exercises/exercise_relation.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/exercises/exercise_version.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/identity_access/auth_session.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/matches/match.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/medical/medical_record.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/notifications/notification_delivery.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/notifications/notification_preferences.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/reports/report_job.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/scout/scout_event.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/seasons/season.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/shared/problem.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/teams/team.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/athlete_chat_message.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/athlete_ineligibility_declaration.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/attention_queue_item.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/execution_record.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/feedback_thread.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/load_chart.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/mesocycle.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/microcycle.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/recommendation.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/session_block.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/session_objective.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/training_session.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/training_suggestion.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/wellness_post.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/training/wellness_pre.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/users/user_profile.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/video/clip_definition.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/video/distribution_profile.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/video/match_media_session.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/video/media_segment.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/wellness/wellness_entry.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/components/schemas/wellness/wellness_summary.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/intents/ai_ingestion.intent.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/intents/examples/ai_ingestion.invalid.intent.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/openapi.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/ai_ingestion.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/analytics.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/audit.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/competitions.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/identity_access.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/matches.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/medical.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/notifications.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/reports.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/scout.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/seasons.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/teams.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/users.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/video.yaml",
+        "/home/davis/HB-TRACK/contracts/openapi/paths/wellness.yaml"
+      ],
       "evidence_files": [],
       "violations": [],
       "metrics": {
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 1107
       }
     },
     {
       "gate_id": "TOOLING_CONFIG_GATE",
-      "status": "SKIP_NOT_APPLICABLE",
+      "status": "PASS",
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Pulado no perfil 'local'.",
+      "summary": "Toolchain/config compatíveis com o pipeline oficial.",
       "inputs": [],
-      "artifacts_checked": [],
+      "artifacts_checked": [
+        "/home/davis/HB-TRACK/package.json",
+        "/home/davis/HB-TRACK/redocly.yaml",
+        "/home/davis/HB-TRACK/docs/_canon/TOOLCHAIN_HEALTH_POLICY.md",
+        "/home/davis/HB-TRACK/contracts/openapi/openapi.yaml"
+      ],
       "evidence_files": [],
       "violations": [],
       "metrics": {
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 4533
       }
     },
     {
@@ -1043,7 +1118,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2587
+        "duration_ms": 1850
       }
     },
     {
@@ -1082,25 +1157,47 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 792
+        "duration_ms": 608
       }
     },
     {
       "gate_id": "OPENAPI_POLICY_RULESET_GATE",
-      "status": "SKIP_NOT_APPLICABLE",
+      "status": "PASS",
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Pulado no perfil 'local'.",
-      "inputs": [],
-      "artifacts_checked": [],
+      "summary": "spectral: PASS (1 aviso(s)).",
+      "inputs": [
+        "/home/davis/HB-TRACK/contracts/openapi/openapi.yaml"
+      ],
+      "artifacts_checked": [
+        "/home/davis/HB-TRACK/contracts/openapi/openapi.yaml"
+      ],
       "evidence_files": [],
-      "violations": [],
+      "violations": [
+        {
+          "blocking_code": "BLOCKED_OPENAPI_POLICY",
+          "artifact": "/home/davis/HB-TRACK/contracts/openapi/openapi.yaml",
+          "message": "[hbtrack-security-global-explicit] security global deve ser declarado explicitamente (mesmo que [])",
+          "severity": "warn",
+          "path": [],
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 315,
+              "character": 69
+            }
+          }
+        }
+      ],
       "metrics": {
         "errors": 0,
-        "warnings": 0,
-        "violations": 0,
-        "duration_ms": 0
+        "warnings": 1,
+        "violations": 1,
+        "duration_ms": 1769
       }
     },
     {
@@ -1109,7 +1206,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "JSON Schema: 47 arquivo(s) válido(s), 0 aviso(s).",
+      "summary": "JSON Schema: 49 arquivo(s) válido(s), 0 aviso(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/schemas/ai_ingestion/ingestion_job.schema.json",
@@ -1132,12 +1229,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/toolchain.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/waiver.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/teams/team.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/training/athlete_chat_conversation.schema.json",
@@ -1166,7 +1265,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 9
+        "duration_ms": 3
       }
     },
     {
@@ -1469,12 +1568,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/toolchain.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/waiver.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/teams/team.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/training/athlete_chat_conversation.schema.json",
@@ -1660,7 +1761,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1744
+        "duration_ms": 1847
       }
     },
     {
@@ -1736,7 +1837,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 5197
+        "duration_ms": 2987
       }
     },
     {
@@ -1779,7 +1880,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 59
+        "duration_ms": 93
       }
     },
     {
@@ -1801,25 +1902,63 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1656
+        "duration_ms": 1862
       }
     },
     {
       "gate_id": "ARAZZO_COMPLETENESS_GATE",
-      "status": "SKIP_NOT_APPLICABLE",
+      "status": "PASS",
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Pulado no perfil 'local'.",
+      "summary": "Completude Arazzo verificada para 13 módulo(s).",
       "inputs": [],
-      "artifacts_checked": [],
+      "artifacts_checked": [
+        "/home/davis/HB-TRACK/docs/_canon/MODULE_REGISTRY.yaml",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
+        "/home/davis/HB-TRACK/contracts/workflows",
+        "/home/davis/HB-TRACK/contracts/workflows/ai_ingestion",
+        "/home/davis/HB-TRACK/contracts/workflows/ai_ingestion/ingestion_job_lifecycle.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/audit",
+        "/home/davis/HB-TRACK/contracts/workflows/audit/cross_module_audit_registration.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/competitions",
+        "/home/davis/HB-TRACK/contracts/workflows/competitions/competition_lifecycle.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/identity_access",
+        "/home/davis/HB-TRACK/contracts/workflows/identity_access/assign_role_to_user.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/matches",
+        "/home/davis/HB-TRACK/contracts/workflows/matches/match_lifecycle.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/notifications",
+        "/home/davis/HB-TRACK/contracts/workflows/notifications/event_to_notification_delivery.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/scout",
+        "/home/davis/HB-TRACK/contracts/workflows/scout/scout_observation_and_session.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/seasons",
+        "/home/davis/HB-TRACK/contracts/workflows/seasons/season_lifecycle.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/teams",
+        "/home/davis/HB-TRACK/contracts/workflows/teams/team_roster_management.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/training",
+        "/home/davis/HB-TRACK/contracts/workflows/training/cancel_training_session.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/training/complete_training_session.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/training/create_training_session_and_mark_attendance.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/training/publish_training_session.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/training/start_training_session.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/users",
+        "/home/davis/HB-TRACK/contracts/workflows/users/user_invitation.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/video",
+        "/home/davis/HB-TRACK/contracts/workflows/video/capture_and_sync.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/video/create_semantic_clip.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/video/semantic_clipping.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/video/start_live_capture.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/video/transcode_and_publish.arazzo.yaml",
+        "/home/davis/HB-TRACK/contracts/workflows/wellness",
+        "/home/davis/HB-TRACK/contracts/workflows/wellness/athlete_wellness_tracking.arazzo.yaml"
+      ],
       "evidence_files": [],
       "violations": [],
       "metrics": {
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 78
       }
     },
     {
@@ -1839,7 +1978,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 9
       }
     },
     {
@@ -1859,7 +1998,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 41487
+        "duration_ms": 49665
       }
     },
     {
@@ -1895,7 +2034,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 22
+        "duration_ms": 19
       }
     },
     {
@@ -1915,7 +2054,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 22
+        "duration_ms": 23
       }
     },
     {
@@ -2036,16 +2175,20 @@
       "inputs": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/ROADMAP.md",
-        "/home/davis/HB-TRACK/.github/workflows/deploy.yml",
-        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py"
+        "/home/davis/HB-TRACK/PLAN_EXEC_PARIDADE.md",
+        "/home/davis/HB-TRACK/PLAN_PARIEDADE.md",
+        "/home/davis/HB-TRACK/toolchain.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/toolchain.schema.json",
+        "/home/davis/HB-TRACK/docs/_canon/RUNTIME_CURRENT_STATE.md"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/ROADMAP.md",
-        "/home/davis/HB-TRACK/.github/workflows/deploy.yml",
-        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py"
+        "/home/davis/HB-TRACK/PLAN_EXEC_PARIDADE.md",
+        "/home/davis/HB-TRACK/PLAN_PARIEDADE.md",
+        "/home/davis/HB-TRACK/toolchain.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/toolchain.schema.json",
+        "/home/davis/HB-TRACK/docs/_canon/RUNTIME_CURRENT_STATE.md"
       ],
       "evidence_files": [],
       "violations": [],
@@ -2053,7 +2196,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 48
+        "duration_ms": 30
       }
     },
     {
@@ -2075,7 +2218,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 197
+        "duration_ms": 200
       }
     },
     {
@@ -2097,7 +2240,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 6
       }
     },
     {
@@ -2157,7 +2300,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 11
+        "duration_ms": 8
       }
     },
     {
@@ -2242,7 +2385,7 @@
       "blocking": false,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Pipeline PASS: 22 PASS, 30 SKIP.",
+      "summary": "Pipeline PASS: 26 PASS, 26 SKIP.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/contract_gates/stage-artifact.local.latest.json
+++ b/_reports/contract_gates/stage-artifact.local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-03-26T11:08:38Z",
+  "timestamp_utc": "2026-04-03T05:33:29Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "791d78b",
+    "git_commit": "7c45aec9",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -17,7 +17,7 @@
       "oasdiff": "oasdiff version 1.12.3",
       "schemathesis": "schemathesis, version 4.12.1",
       "json_schema_validator": null,
-      "asyncapi_validator": "@asyncapi/cli/6.0.0 wsl-x64 node-v24.14.0",
+      "asyncapi_validator": "@asyncapi/cli/6.0.0 wsl-x64 node-v24.14.1",
       "arazzo_validator": null,
       "storybook": null
     }
@@ -31,7 +31,7 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-artifact.local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260326T110838_2f231e"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260403T053329_961abb"
   },
   "status_detail": {
     "active_gates_passed": 8,
@@ -229,7 +229,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 47
+        "duration_ms": 51
       }
     },
     {
@@ -254,7 +254,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 597
+        "duration_ms": 1836
       }
     },
     {
@@ -533,7 +533,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Nenhum token placeholder em 351 arquivo(s) verificado(s).",
+      "summary": "Nenhum token placeholder em 353 arquivo(s) verificado(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/_waivers/CONTRACT_BREAKING_CHANGE_GATE/README.md",
@@ -835,12 +835,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/toolchain.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/waiver.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/teams/team.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/training/athlete_chat_conversation.schema.json",
@@ -894,7 +896,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 29
+        "duration_ms": 74
       }
     },
     {
@@ -952,7 +954,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 712
+        "duration_ms": 1328
       }
     },
     {
@@ -997,7 +999,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "JSON Schema: 47 arquivo(s) válido(s), 0 aviso(s).",
+      "summary": "JSON Schema: 49 arquivo(s) válido(s), 0 aviso(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/schemas/ai_ingestion/ingestion_job.schema.json",
@@ -1020,12 +1022,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/toolchain.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/waiver.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/teams/team.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/training/athlete_chat_conversation.schema.json",
@@ -1218,7 +1222,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 3
       }
     },
     {
@@ -1456,7 +1460,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 24
+        "duration_ms": 23
       }
     },
     {

--- a/_reports/session_start.json
+++ b/_reports/session_start.json
@@ -5,7 +5,7 @@
   "pipeline_version": "1.0.0",
   "boot_profile_id": "roadmap_execution",
   "task_type": "execute_roadmap_phase",
-  "stage": 0,
+  "stage": 2,
   "write_scope": "roadmap",
   "worker_id": "execute_roadmap_phase",
   "git_user": "HB Track Agent",
@@ -23,9 +23,9 @@
   "stage0_exit_code": 0,
   "hook_exit_code": 0,
   "hook_validated_at": "2026-03-27T23:10:14.973783+00:00",
-  "module_focus": "training",
+  "module_focus": "parity",
   "stage3_exit_code": 2,
-  "roadmap_task_id": "roadmap-fase5-frontend-ciclo1",
+  "roadmap_task_id": "parity-enforcement-toolchain",
   "module": "training",
   "stage2_artifacts": [
     {
@@ -56,6 +56,18 @@
       "path": "contracts/openapi/spectral_lint.log",
       "sha256": "20dacc396fb2ab9ddaf802b5703aa67218b93ac39fae1fd982294d0798f65328",
       "created_at": "2026-03-26T11:08:38.343345+00:00",
+      "gate_exit_code": 0
+    },
+    {
+      "path": "merge-readiness.json",
+      "sha256": "e6adde23030098ba81d0f5517bd21f5e9c769bdcc9097e0865c558eb81b8ccd3",
+      "created_at": "2026-04-03T05:33:17.730019+00:00",
+      "gate_exit_code": 0
+    },
+    {
+      "path": "contracts/schemas/shared/merge-readiness.schema.json",
+      "sha256": "5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38",
+      "created_at": "2026-04-03T05:33:29.345119+00:00",
       "gate_exit_code": 0
     }
   ],

--- a/contracts/schemas/shared/merge-readiness.schema.json
+++ b/contracts/schemas/shared/merge-readiness.schema.json
@@ -1,0 +1,194 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://hbtrack.dev/schemas/merge-readiness",
+    "title": "HB Track Merge-Readiness Manifest",
+    "description": "Declaração formal dos checks que bloqueiam merge em main, checks informativos e condicionais, e o executor local equivalente para cada um.",
+    "type": "object",
+    "required": [
+        "version",
+        "target_branch",
+        "ruleset_name",
+        "checks",
+        "enforcement",
+        "local_executor"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "updated": {
+            "type": "string",
+            "format": "date"
+        },
+        "target_branch": {
+            "type": "string"
+        },
+        "ruleset_name": {
+            "type": "string"
+        },
+        "ruleset_id": {
+            "type": "integer"
+        },
+        "checks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "context",
+                    "workflow",
+                    "job",
+                    "category"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "context": {
+                        "type": "string",
+                        "description": "Nome exato do check context como registrado no ruleset do GitHub."
+                    },
+                    "workflow": {
+                        "type": "string",
+                        "description": "Arquivo de workflow (.yml) que contém o job."
+                    },
+                    "job": {
+                        "type": "string",
+                        "description": "ID do job dentro do workflow."
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "required",
+                            "informational",
+                            "conditional"
+                        ],
+                        "description": "required = bloqueia merge no ruleset. informational = roda mas não bloqueia. conditional = roda apenas quando condição de path-filter é verdadeira."
+                    },
+                    "local_equivalent": {
+                        "type": "string",
+                        "description": "Comando local que reproduz este check. Obrigatório para category=required."
+                    },
+                    "condition": {
+                        "type": "string",
+                        "description": "Expressão que ativa o check. Obrigatório para category=conditional."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Justificativa de não ser required. Obrigatório para category=informational e category=conditional."
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "required"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "local_equivalent"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "conditional"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "condition",
+                                "reason"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "informational"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "reason"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "enforcement": {
+            "type": "object",
+            "required": [
+                "require_pr",
+                "require_conversation_resolution",
+                "require_up_to_date",
+                "block_force_push",
+                "bypass_actors"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "require_pr": {
+                    "type": "boolean"
+                },
+                "require_conversation_resolution": {
+                    "type": "boolean"
+                },
+                "require_up_to_date": {
+                    "type": "boolean"
+                },
+                "block_force_push": {
+                    "type": "boolean"
+                },
+                "block_deletion": {
+                    "type": "boolean"
+                },
+                "bypass_actors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "local_executor": {
+            "type": "object",
+            "required": [
+                "command",
+                "evidence_path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "evidence_path": {
+                    "type": "string"
+                },
+                "pre_push_hook": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/generated/contracts/schemas/shared/merge-readiness.schema.json
+++ b/generated/contracts/schemas/shared/merge-readiness.schema.json
@@ -1,0 +1,194 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://hbtrack.dev/schemas/merge-readiness",
+    "title": "HB Track Merge-Readiness Manifest",
+    "description": "Declaração formal dos checks que bloqueiam merge em main, checks informativos e condicionais, e o executor local equivalente para cada um.",
+    "type": "object",
+    "required": [
+        "version",
+        "target_branch",
+        "ruleset_name",
+        "checks",
+        "enforcement",
+        "local_executor"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "updated": {
+            "type": "string",
+            "format": "date"
+        },
+        "target_branch": {
+            "type": "string"
+        },
+        "ruleset_name": {
+            "type": "string"
+        },
+        "ruleset_id": {
+            "type": "integer"
+        },
+        "checks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "context",
+                    "workflow",
+                    "job",
+                    "category"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "context": {
+                        "type": "string",
+                        "description": "Nome exato do check context como registrado no ruleset do GitHub."
+                    },
+                    "workflow": {
+                        "type": "string",
+                        "description": "Arquivo de workflow (.yml) que contém o job."
+                    },
+                    "job": {
+                        "type": "string",
+                        "description": "ID do job dentro do workflow."
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "required",
+                            "informational",
+                            "conditional"
+                        ],
+                        "description": "required = bloqueia merge no ruleset. informational = roda mas não bloqueia. conditional = roda apenas quando condição de path-filter é verdadeira."
+                    },
+                    "local_equivalent": {
+                        "type": "string",
+                        "description": "Comando local que reproduz este check. Obrigatório para category=required."
+                    },
+                    "condition": {
+                        "type": "string",
+                        "description": "Expressão que ativa o check. Obrigatório para category=conditional."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Justificativa de não ser required. Obrigatório para category=informational e category=conditional."
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "required"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "local_equivalent"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "conditional"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "condition",
+                                "reason"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "informational"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "reason"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "enforcement": {
+            "type": "object",
+            "required": [
+                "require_pr",
+                "require_conversation_resolution",
+                "require_up_to_date",
+                "block_force_push",
+                "bypass_actors"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "require_pr": {
+                    "type": "boolean"
+                },
+                "require_conversation_resolution": {
+                    "type": "boolean"
+                },
+                "require_up_to_date": {
+                    "type": "boolean"
+                },
+                "block_force_push": {
+                    "type": "boolean"
+                },
+                "block_deletion": {
+                    "type": "boolean"
+                },
+                "bypass_actors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "local_executor": {
+            "type": "object",
+            "required": [
+                "command",
+                "evidence_path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "evidence_path": {
+                    "type": "string"
+                },
+                "pre_push_hook": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/generated/manifests/ai_ingestion.event.traceability.yaml
+++ b/generated/manifests/ai_ingestion.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/ai_ingestion.event.resolved.yaml
-  policy_sha256: a04eed6f1278a067628ffb08c134fb3ee4404b635cbbc1b51243e44513fc5dce
+  policy_sha256: 6467a32c5df7c998ffbfb0b54b7d1fd20d2e8ca81cacaa172762025d957fb9b7
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/ai_ingestion.sync.traceability.yaml
+++ b/generated/manifests/ai_ingestion.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/ai_ingestion.sync.resolved.yaml
-  policy_sha256: d51f56f1514a2471dc232065e7d873d29e0ed015e1e3385efe6a605c498ef76e
+  policy_sha256: 52ac9f36b6b01483a49e4602a1b36f63e67970ea4f34040ce1d943b7dd69fdcf
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/analytics.sync.traceability.yaml
+++ b/generated/manifests/analytics.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/analytics.sync.resolved.yaml
-  policy_sha256: 4f6a60f040d4466e69cc87371be310f78df1384309308ddebeaabad3525c53ab
+  policy_sha256: 9253ea60253436a324acddf89ffe89eb5229d65431feab9a7fcefe68bda8cb5f
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/audit.event.traceability.yaml
+++ b/generated/manifests/audit.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/audit.event.resolved.yaml
-  policy_sha256: 9e5d8f79ec4c55c538176d1b9c1d8a29f702d3d2fe768dedd2696509ca627466
+  policy_sha256: c3adf874ade32b4fbf71d65bc036b0b5b073474ff776a94f6750a0337c337391
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/audit.sync.traceability.yaml
+++ b/generated/manifests/audit.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/audit.sync.resolved.yaml
-  policy_sha256: 9be24705e3c1b519a8f19c999a0c5b477f7de8022d74e7835c5de596786c7d98
+  policy_sha256: 5abe9b07d08823a2855fa141e683c1cf2839fe770e033a90a3604278ab53525e
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/competitions.event.traceability.yaml
+++ b/generated/manifests/competitions.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/competitions.event.resolved.yaml
-  policy_sha256: 1e6038af50d5b5654fd01e51bfe83190bcb40e1e1d29c23a32c74cd8a21e7ae1
+  policy_sha256: ba3924dfeb13a523381e8c1a9af3828500a4f51a2826bd9db45c4cd70e47467d
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/competitions.sync.traceability.yaml
+++ b/generated/manifests/competitions.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/competitions.sync.resolved.yaml
-  policy_sha256: d704184ddb5c3035c84577b180844b938f516890633805dee8a7529cb01d2ea7
+  policy_sha256: 591274cfb335a99d15510d648d97f0ded7162dc8eedad520ef0c6f4adace3bcb
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/exercises.sync.traceability.yaml
+++ b/generated/manifests/exercises.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/exercises.sync.resolved.yaml
-  policy_sha256: b5a8ed7d7214a1fb38d170e7435882cec4b3dd1acabb941111bff22cdbab87de
+  policy_sha256: b1ece6726862014e9dc39e228c4c4f483e479d67edf6ae8d9e4197983b1aaac6
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/identity_access.event.traceability.yaml
+++ b/generated/manifests/identity_access.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/identity_access.event.resolved.yaml
-  policy_sha256: c92fbc8b7205409e39a171349e928ab3f5f165b0def93df8a1de38e8a7dc3f6f
+  policy_sha256: ca50254107156121a6508fc9ec4443c3883b8da45e93b01518882fe1801922f9
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/identity_access.sync.traceability.yaml
+++ b/generated/manifests/identity_access.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/identity_access.sync.resolved.yaml
-  policy_sha256: da8fbd780dc74f3a81dfce710a42133657e99fd795570df48cc455ae6e779077
+  policy_sha256: f05943b30f1e48741b13995b2c76e6738edd7a8c570c0fe85421b9127b2144f6
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/matches.event.traceability.yaml
+++ b/generated/manifests/matches.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/matches.event.resolved.yaml
-  policy_sha256: fcacffd9e1e9084623b8a7680f5b3199420ab9d0c4cf2c808cfae9161a2bb32e
+  policy_sha256: 9a43cbc31d9d468f97a93853fb361a01790156bf25be26ca0672c4f775e886c4
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/matches.sync.traceability.yaml
+++ b/generated/manifests/matches.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/matches.sync.resolved.yaml
-  policy_sha256: f8c67194e47f0e86b631cc43f4728f609ac460111647c1c7c3548c6e10c46650
+  policy_sha256: 6c6058d1f57fd877877d5fd859b02e05f1b1054dfa4436801fe71607d01677bc
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/medical.sync.traceability.yaml
+++ b/generated/manifests/medical.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/medical.sync.resolved.yaml
-  policy_sha256: 3cd3046d7e2f8806415922ed6366d416d577bd6420acedd98ea8ef0094d495b0
+  policy_sha256: a60c1212ee1057921131dd9bd3d6081635bfff6ba60a2846ad914eeca0179ad6
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/notifications.event.traceability.yaml
+++ b/generated/manifests/notifications.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/notifications.event.resolved.yaml
-  policy_sha256: 16f92846fcfd187bdec133ac8490e8f32f3cb707aed245c2dfe19bb6ecea9d6b
+  policy_sha256: ccd779eeb09ef51fd3187069de1b6c862e40988f2359d7b4c7ceee3ee976e5b9
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/notifications.sync.traceability.yaml
+++ b/generated/manifests/notifications.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/notifications.sync.resolved.yaml
-  policy_sha256: ffa88ce4bda0cd4c23d1420e8480e1d75a7a6408f443315812b3e81f1ae37d9f
+  policy_sha256: 83a727131dd51a78baa63501c7bf4a400fa9e510ccfb5e9403f518d24e45c45e
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/reports.sync.traceability.yaml
+++ b/generated/manifests/reports.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/reports.sync.resolved.yaml
-  policy_sha256: b86a2168a6fcb13357e681e31e6cc84b4868a13fe305477085c34fc8b04fc553
+  policy_sha256: af2bdfc19bc3d4178ac264e891f9f92490a1e23f8bcfa988c85abc869b6f8824
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/scout.event.traceability.yaml
+++ b/generated/manifests/scout.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/scout.event.resolved.yaml
-  policy_sha256: 0abe472462b3752a7a02b564949f6b025679b4805a83244c169cf4b44eaed86e
+  policy_sha256: c37759422426321857b5af325c56136dc9da16da121c9a28dafbea0d0efd8792
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/scout.sync.traceability.yaml
+++ b/generated/manifests/scout.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/scout.sync.resolved.yaml
-  policy_sha256: f7e0d82e1bdc6b452bc09e714d6bcd5104f46724dc0da6df40727c1294748fc5
+  policy_sha256: 25b96178996244fef91b8fb2956b837b24014b8b729fed8483a96fc3c9f71013
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/seasons.event.traceability.yaml
+++ b/generated/manifests/seasons.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/seasons.event.resolved.yaml
-  policy_sha256: 421970243f0b990b4541bced90d22d6e24503974d2c9d31f78c026f7754ef562
+  policy_sha256: c916ed291807667a8c44a7f8c7ed88c332d6856d8d81c69885784e0ac0512f9d
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/seasons.sync.traceability.yaml
+++ b/generated/manifests/seasons.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/seasons.sync.resolved.yaml
-  policy_sha256: 6b6805f8f5f79874322c4aa0f93e693f9fcea7dd4641f6e1f273469cf35e5021
+  policy_sha256: b90a7508b2deae2aac07b45443e37e35f02ff7a7d2b6982dba7e1ff4e88ad033
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/teams.event.traceability.yaml
+++ b/generated/manifests/teams.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/teams.event.resolved.yaml
-  policy_sha256: b76b6cf25b4e505899d0bfd4cdc4817984b525b1f489fc0069842c54f4a5ce44
+  policy_sha256: bb887c8b11c272b0df4f22648d075ba353bdeea6766d0ed173fe1b2e983b0630
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/teams.sync.traceability.yaml
+++ b/generated/manifests/teams.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/teams.sync.resolved.yaml
-  policy_sha256: 6a659319ac6364ac21794e05e752f29670cd463c9dd907484a1cd916d235d108
+  policy_sha256: 64d646925b2dbb2cc96a4a81aa26a13df78f0feaea8de59e35d7f9ab0b8b40a1
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/training.event.traceability.yaml
+++ b/generated/manifests/training.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/training.event.resolved.yaml
-  policy_sha256: 3b24212bdbf407f50222b2e46826a8f5512627aa2e8bc6230a6db3837f9f5bc3
+  policy_sha256: 4b3aefc621da12bbb1e5d4059b6bcd0c2112b1d251a91fec174b6da2ca6cde32
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/training.sync.traceability.yaml
+++ b/generated/manifests/training.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/training.sync.resolved.yaml
-  policy_sha256: 1b8cbf1cd851c94b8eea0600c9e0ba094b8f0dee567bfb7825ff5925ff94f5de
+  policy_sha256: d3591622491ae0cc0077307298ac18eb8074d287a5cc76ac458c2047152c3a5c
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/users.event.traceability.yaml
+++ b/generated/manifests/users.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/users.event.resolved.yaml
-  policy_sha256: e91ce24b80506d16e54cbf3590011e1a34210d735fe3f819b87c519c65e50f40
+  policy_sha256: 10ae6ca9cb23331aa39015c6db26824efc07cf793f01553a4d2a773a6d393b21
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/users.sync.traceability.yaml
+++ b/generated/manifests/users.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/users.sync.resolved.yaml
-  policy_sha256: ed8a6b9202980b4e925a8b520735b97467bd60801aebb90e94335fc8883e82ee
+  policy_sha256: 7c79cffebeace077d94553e34e85ac59fc167071d70cf9df0f33e2e5fc3e1c33
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/video.event.traceability.yaml
+++ b/generated/manifests/video.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/video.event.resolved.yaml
-  policy_sha256: 11500ce506cd91e53fdea1fd16bf48a98929c781de9865a253311d6206a340c5
+  policy_sha256: 3a0ac2e06a2e32ffd56d62ed096899c9abce421bc6b92dafe4391e32454d0535
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/video.sync.traceability.yaml
+++ b/generated/manifests/video.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/video.sync.resolved.yaml
-  policy_sha256: 6cab62b797bfbbba9c751eb058f98da7db06d1cf021f17c9992ac5645e08db2c
+  policy_sha256: 283c3628bd1d16a2f4b2a97deacfae352d27c2d5a9d87591f403de0fa4a6ac5c
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/wellness.event.traceability.yaml
+++ b/generated/manifests/wellness.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/wellness.event.resolved.yaml
-  policy_sha256: 66487c5fdeb182833f4e9c0d7772e23da29d05ba5f564e76f395cdc49a34b313
+  policy_sha256: 87bd08840d60a361e67888986ce47ae7b761a0fc08ce76b595397204c4f807f9
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/wellness.sync.traceability.yaml
+++ b/generated/manifests/wellness.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/wellness.sync.resolved.yaml
-  policy_sha256: ff4d98976f55a78738ebfd59a3fcb91359256387158990f02b7056fd427af8cd
+  policy_sha256: b19ab3f45f14104af07fd7def936ce4cf70ac4e369d1ac874d6536d6ba5a0d2e
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/resolved_policy/ai_ingestion.event.resolved.yaml
+++ b/generated/resolved_policy/ai_ingestion.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/ai_ingestion.sync.resolved.yaml
+++ b/generated/resolved_policy/ai_ingestion.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/analytics.sync.resolved.yaml
+++ b/generated/resolved_policy/analytics.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/audit.event.resolved.yaml
+++ b/generated/resolved_policy/audit.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/audit.sync.resolved.yaml
+++ b/generated/resolved_policy/audit.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/competitions.event.resolved.yaml
+++ b/generated/resolved_policy/competitions.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/competitions.sync.resolved.yaml
+++ b/generated/resolved_policy/competitions.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/exercises.sync.resolved.yaml
+++ b/generated/resolved_policy/exercises.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/identity_access.event.resolved.yaml
+++ b/generated/resolved_policy/identity_access.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/identity_access.sync.resolved.yaml
+++ b/generated/resolved_policy/identity_access.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/matches.event.resolved.yaml
+++ b/generated/resolved_policy/matches.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/matches.sync.resolved.yaml
+++ b/generated/resolved_policy/matches.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/medical.sync.resolved.yaml
+++ b/generated/resolved_policy/medical.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/notifications.event.resolved.yaml
+++ b/generated/resolved_policy/notifications.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/notifications.sync.resolved.yaml
+++ b/generated/resolved_policy/notifications.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/reports.sync.resolved.yaml
+++ b/generated/resolved_policy/reports.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/scout.event.resolved.yaml
+++ b/generated/resolved_policy/scout.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/scout.sync.resolved.yaml
+++ b/generated/resolved_policy/scout.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/seasons.event.resolved.yaml
+++ b/generated/resolved_policy/seasons.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/seasons.sync.resolved.yaml
+++ b/generated/resolved_policy/seasons.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/teams.event.resolved.yaml
+++ b/generated/resolved_policy/teams.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/teams.sync.resolved.yaml
+++ b/generated/resolved_policy/teams.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/training.event.resolved.yaml
+++ b/generated/resolved_policy/training.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/training.sync.resolved.yaml
+++ b/generated/resolved_policy/training.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/users.event.resolved.yaml
+++ b/generated/resolved_policy/users.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/users.sync.resolved.yaml
+++ b/generated/resolved_policy/users.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/video.event.resolved.yaml
+++ b/generated/resolved_policy/video.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/video.sync.resolved.yaml
+++ b/generated/resolved_policy/video.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/wellness.event.resolved.yaml
+++ b/generated/resolved_policy/wellness.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/wellness.sync.resolved.yaml
+++ b/generated/resolved_policy/wellness.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/merge-readiness.json
+++ b/merge-readiness.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "./contracts/schemas/shared/merge-readiness.schema.json",
+    "version": "1.0.0",
+    "updated": "2026-04-03",
+    "target_branch": "main",
+    "ruleset_name": "contract-gates",
+    "ruleset_id": 13901517,
+    "checks": [
+        {
+            "context": "Validate Contract Gates",
+            "workflow": "contract-gates.yml",
+            "job": "validate-contracts",
+            "category": "required",
+            "local_equivalent": "python3 scripts/hb preflight (STEP 3)"
+        },
+        {
+            "context": "Governance Tests",
+            "workflow": "contract-gates.yml",
+            "job": "governance-tests",
+            "category": "required",
+            "local_equivalent": "pytest tests/test_pipeline_governance.py"
+        },
+        {
+            "context": "Architecture Drift Check",
+            "workflow": "contract-gates.yml",
+            "job": "architecture-drift-check",
+            "category": "required",
+            "local_equivalent": "python3 scripts/audit/check_architecture_docs.py --json && pytest tests/pipeline_gates/test_architecture_drift.py"
+        },
+        {
+            "context": "Validate Contracts",
+            "workflow": "ci.yml",
+            "job": "validate",
+            "category": "required",
+            "local_equivalent": "python3 scripts/contracts/validate/validate_contracts.py"
+        },
+        {
+            "context": "Tests",
+            "workflow": "ci.yml",
+            "job": "test",
+            "category": "required",
+            "local_equivalent": "pytest -q"
+        },
+        {
+            "context": "Frontend Build + Tests",
+            "workflow": "ci.yml",
+            "job": "build-frontend",
+            "category": "required",
+            "local_equivalent": "npm --prefix frontend ci && npm --prefix frontend run build && npm --prefix frontend test"
+        },
+        {
+            "context": "Docker Build Check",
+            "workflow": "ci.yml",
+            "job": "build",
+            "category": "informational",
+            "reason": "Valida Dockerfile mas não bloqueia merge — falha de build de imagem não impede integração de código"
+        },
+        {
+            "context": "Governance Enforcement (survival-suite)",
+            "workflow": "contract-gates.yml",
+            "job": "governance-enforcement",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — só roda quando arquivos de governança (.contract_driven/, contracts/, docs/_canon/) são modificados"
+        },
+        {
+            "context": "Paridade Registry × Executor",
+            "workflow": "contract-gates.yml",
+            "job": "registry-executor-parity",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — verifica paridade entre MODULE_REGISTRY.yaml e executores; ativado apenas em mudanças de governança"
+        },
+        {
+            "context": "Paridade Schema × Template × Skills",
+            "workflow": "contract-gates.yml",
+            "job": "schema-template-skills-parity",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — verifica paridade entre schemas, templates e skills; ativado apenas em mudanças de governança"
+        },
+        {
+            "context": "Validação Cruzada SESSION_HANDOFF ↔ session_start",
+            "workflow": "contract-gates.yml",
+            "job": "session-handoff-crossval",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — cross-valida SESSION_HANDOFF.md contra session_start workflow; ativado apenas em mudanças de governança"
+        }
+    ],
+    "enforcement": {
+        "require_pr": true,
+        "require_conversation_resolution": true,
+        "require_up_to_date": true,
+        "block_force_push": true,
+        "block_deletion": true,
+        "bypass_actors": []
+    },
+    "local_executor": {
+        "command": "python3 scripts/hb preflight",
+        "evidence_path": "_reports/preflight/latest.json",
+        "pre_push_hook": "scripts/git-hooks/pre-push"
+    }
+}


### PR DESCRIPTION
## Entregável 3 — Manifesto canônico de merge-readiness

> Parte do [PLAN_EXEC_PARIDADE.md](../blob/main/PLAN_EXEC_PARIDADE.md). Sequência: E1 (#31 ✅) → E2 (#32 ✅) → **E3 (este PR)** → E4 → E5 → E6

### Problema que resolve

Não existia declaração formal de quais checks bloqueiam merge, quais são informativos, e qual executor local reproduz cada um. O ruleset (E1) configura isso no GitHub, mas sem rastreabilidade versionada. Se alguém alterar o ruleset pela UI, não há como detectar drift.

### Arquivos criados

| Arquivo | Propósito |
|---|---|
| `merge-readiness.json` | SSOT dos checks de merge — 6 required, 1 informational, 4 conditional |
| `contracts/schemas/shared/merge-readiness.schema.json` | JSON Schema Draft-2020-12 com `additionalProperties:false` + `allOf/if/then` por categoria |

### Checks required (6 — estado atual do ruleset 13901517)

| Context | Executor local |
|---|---|
| Validate Contract Gates | `python3 scripts/hb preflight (STEP 3)` |
| Governance Tests | `pytest tests/test_pipeline_governance.py` |
| Architecture Drift Check | `python3 scripts/audit/check_architecture_docs.py --json && pytest tests/pipeline_gates/test_architecture_drift.py` |
| Validate Contracts | `python3 scripts/contracts/validate/validate_contracts.py` |
| Tests | `pytest -q` |
| Frontend Build + Tests | `npm --prefix frontend ci && npm --prefix frontend run build && npm --prefix frontend test` |

> ⚠️ Adversarial Suite **não está** neste PR — foi removida em E1 e será reintroduzida em E4.

### Validação local

```
python3 -c "import json,jsonschema; jsonschema.validate(json.load(open('merge-readiness.json')), json.load(open('contracts/schemas/shared/merge-readiness.schema.json')))"
# → PASS
jq '[.checks[] | select(.category == "required")] | length' merge-readiness.json
# → 6
validate_contracts.py → STATUS: PASS
```

### Critério de done

- [x] `merge-readiness.json` válido contra schema (allOf/if/then)
- [x] Todo `required` tem `local_equivalent`
- [x] Todo `conditional` tem `condition + reason`
- [x] Contexts batem exatamente com ruleset API (case-sensitive)
- [x] Sem Adversarial Suite (estado atual = 6 required)
- [x] Artefatos `generated/` recompilados (DERIVED_DRIFT_GATE=PASS)
- [x] Todos os gates locais = PASS