### PR TITLE
feat(parity/E3): merge-readiness manifest — SSOT de checks que bloqueiam merge

### DIFF
--- a/contracts/schemas/shared/merge-readiness.schema.json
+++ b/contracts/schemas/shared/merge-readiness.schema.json
@@ -1,0 +1,194 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://hbtrack.dev/schemas/merge-readiness",
+    "title": "HB Track Merge-Readiness Manifest",
+    "description": "Declaração formal dos checks que bloqueiam merge em main, checks informativos e condicionais, e o executor local equivalente para cada um.",
+    "type": "object",
+    "required": [
+        "version",
+        "target_branch",
+        "ruleset_name",
+        "checks",
+        "enforcement",
+        "local_executor"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "updated": {
+            "type": "string",
+            "format": "date"
+        },
+        "target_branch": {
+            "type": "string"
+        },
+        "ruleset_name": {
+            "type": "string"
+        },
+        "ruleset_id": {
+            "type": "integer"
+        },
+        "checks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "context",
+                    "workflow",
+                    "job",
+                    "category"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "context": {
+                        "type": "string",
+                        "description": "Nome exato do check context como registrado no ruleset do GitHub."
+                    },
+                    "workflow": {
+                        "type": "string",
+                        "description": "Arquivo de workflow (.yml) que contém o job."
+                    },
+                    "job": {
+                        "type": "string",
+                        "description": "ID do job dentro do workflow."
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "required",
+                            "informational",
+                            "conditional"
+                        ],
+                        "description": "required = bloqueia merge no ruleset. informational = roda mas não bloqueia. conditional = roda apenas quando condição de path-filter é verdadeira."
+                    },
+                    "local_equivalent": {
+                        "type": "string",
+                        "description": "Comando local que reproduz este check. Obrigatório para category=required."
+                    },
+                    "condition": {
+                        "type": "string",
+                        "description": "Expressão que ativa o check. Obrigatório para category=conditional."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Justificativa de não ser required. Obrigatório para category=informational e category=conditional."
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "required"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "local_equivalent"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "conditional"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "condition",
+                                "reason"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "informational"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "reason"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "enforcement": {
+            "type": "object",
+            "required": [
+                "require_pr",
+                "require_conversation_resolution",
+                "require_up_to_date",
+                "block_force_push",
+                "bypass_actors"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "require_pr": {
+                    "type": "boolean"
+                },
+                "require_conversation_resolution": {
+                    "type": "boolean"
+                },
+                "require_up_to_date": {
+                    "type": "boolean"
+                },
+                "block_force_push": {
+                    "type": "boolean"
+                },
+                "block_deletion": {
+                    "type": "boolean"
+                },
+                "bypass_actors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "local_executor": {
+            "type": "object",
+            "required": [
+                "command",
+                "evidence_path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "evidence_path": {
+                    "type": "string"
+                },
+                "pre_push_hook": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/generated/contracts/schemas/shared/merge-readiness.schema.json
+++ b/generated/contracts/schemas/shared/merge-readiness.schema.json
@@ -1,0 +1,194 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://hbtrack.dev/schemas/merge-readiness",
+    "title": "HB Track Merge-Readiness Manifest",
+    "description": "Declaração formal dos checks que bloqueiam merge em main, checks informativos e condicionais, e o executor local equivalente para cada um.",
+    "type": "object",
+    "required": [
+        "version",
+        "target_branch",
+        "ruleset_name",
+        "checks",
+        "enforcement",
+        "local_executor"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "updated": {
+            "type": "string",
+            "format": "date"
+        },
+        "target_branch": {
+            "type": "string"
+        },
+        "ruleset_name": {
+            "type": "string"
+        },
+        "ruleset_id": {
+            "type": "integer"
+        },
+        "checks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "context",
+                    "workflow",
+                    "job",
+                    "category"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "context": {
+                        "type": "string",
+                        "description": "Nome exato do check context como registrado no ruleset do GitHub."
+                    },
+                    "workflow": {
+                        "type": "string",
+                        "description": "Arquivo de workflow (.yml) que contém o job."
+                    },
+                    "job": {
+                        "type": "string",
+                        "description": "ID do job dentro do workflow."
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "required",
+                            "informational",
+                            "conditional"
+                        ],
+                        "description": "required = bloqueia merge no ruleset. informational = roda mas não bloqueia. conditional = roda apenas quando condição de path-filter é verdadeira."
+                    },
+                    "local_equivalent": {
+                        "type": "string",
+                        "description": "Comando local que reproduz este check. Obrigatório para category=required."
+                    },
+                    "condition": {
+                        "type": "string",
+                        "description": "Expressão que ativa o check. Obrigatório para category=conditional."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Justificativa de não ser required. Obrigatório para category=informational e category=conditional."
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "required"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "local_equivalent"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "conditional"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "condition",
+                                "reason"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "category": {
+                                    "const": "informational"
+                                }
+                            },
+                            "required": [
+                                "category"
+                            ]
+                        },
+                        "then": {
+                            "required": [
+                                "reason"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "enforcement": {
+            "type": "object",
+            "required": [
+                "require_pr",
+                "require_conversation_resolution",
+                "require_up_to_date",
+                "block_force_push",
+                "bypass_actors"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "require_pr": {
+                    "type": "boolean"
+                },
+                "require_conversation_resolution": {
+                    "type": "boolean"
+                },
+                "require_up_to_date": {
+                    "type": "boolean"
+                },
+                "block_force_push": {
+                    "type": "boolean"
+                },
+                "block_deletion": {
+                    "type": "boolean"
+                },
+                "bypass_actors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "local_executor": {
+            "type": "object",
+            "required": [
+                "command",
+                "evidence_path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "evidence_path": {
+                    "type": "string"
+                },
+                "pre_push_hook": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/generated/manifests/ai_ingestion.event.traceability.yaml
+++ b/generated/manifests/ai_ingestion.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/ai_ingestion.event.resolved.yaml
-  policy_sha256: a04eed6f1278a067628ffb08c134fb3ee4404b635cbbc1b51243e44513fc5dce
+  policy_sha256: 6467a32c5df7c998ffbfb0b54b7d1fd20d2e8ca81cacaa172762025d957fb9b7
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/ai_ingestion.sync.traceability.yaml
+++ b/generated/manifests/ai_ingestion.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/ai_ingestion.sync.resolved.yaml
-  policy_sha256: d51f56f1514a2471dc232065e7d873d29e0ed015e1e3385efe6a605c498ef76e
+  policy_sha256: 52ac9f36b6b01483a49e4602a1b36f63e67970ea4f34040ce1d943b7dd69fdcf
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/analytics.sync.traceability.yaml
+++ b/generated/manifests/analytics.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/analytics.sync.resolved.yaml
-  policy_sha256: 4f6a60f040d4466e69cc87371be310f78df1384309308ddebeaabad3525c53ab
+  policy_sha256: 9253ea60253436a324acddf89ffe89eb5229d65431feab9a7fcefe68bda8cb5f
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/audit.event.traceability.yaml
+++ b/generated/manifests/audit.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/audit.event.resolved.yaml
-  policy_sha256: 9e5d8f79ec4c55c538176d1b9c1d8a29f702d3d2fe768dedd2696509ca627466
+  policy_sha256: c3adf874ade32b4fbf71d65bc036b0b5b073474ff776a94f6750a0337c337391
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/audit.sync.traceability.yaml
+++ b/generated/manifests/audit.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/audit.sync.resolved.yaml
-  policy_sha256: 9be24705e3c1b519a8f19c999a0c5b477f7de8022d74e7835c5de596786c7d98
+  policy_sha256: 5abe9b07d08823a2855fa141e683c1cf2839fe770e033a90a3604278ab53525e
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/competitions.event.traceability.yaml
+++ b/generated/manifests/competitions.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/competitions.event.resolved.yaml
-  policy_sha256: 1e6038af50d5b5654fd01e51bfe83190bcb40e1e1d29c23a32c74cd8a21e7ae1
+  policy_sha256: ba3924dfeb13a523381e8c1a9af3828500a4f51a2826bd9db45c4cd70e47467d
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/competitions.sync.traceability.yaml
+++ b/generated/manifests/competitions.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/competitions.sync.resolved.yaml
-  policy_sha256: d704184ddb5c3035c84577b180844b938f516890633805dee8a7529cb01d2ea7
+  policy_sha256: 591274cfb335a99d15510d648d97f0ded7162dc8eedad520ef0c6f4adace3bcb
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/exercises.sync.traceability.yaml
+++ b/generated/manifests/exercises.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/exercises.sync.resolved.yaml
-  policy_sha256: b5a8ed7d7214a1fb38d170e7435882cec4b3dd1acabb941111bff22cdbab87de
+  policy_sha256: b1ece6726862014e9dc39e228c4c4f483e479d67edf6ae8d9e4197983b1aaac6
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/identity_access.event.traceability.yaml
+++ b/generated/manifests/identity_access.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/identity_access.event.resolved.yaml
-  policy_sha256: c92fbc8b7205409e39a171349e928ab3f5f165b0def93df8a1de38e8a7dc3f6f
+  policy_sha256: ca50254107156121a6508fc9ec4443c3883b8da45e93b01518882fe1801922f9
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/identity_access.sync.traceability.yaml
+++ b/generated/manifests/identity_access.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/identity_access.sync.resolved.yaml
-  policy_sha256: da8fbd780dc74f3a81dfce710a42133657e99fd795570df48cc455ae6e779077
+  policy_sha256: f05943b30f1e48741b13995b2c76e6738edd7a8c570c0fe85421b9127b2144f6
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/matches.event.traceability.yaml
+++ b/generated/manifests/matches.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/matches.event.resolved.yaml
-  policy_sha256: fcacffd9e1e9084623b8a7680f5b3199420ab9d0c4cf2c808cfae9161a2bb32e
+  policy_sha256: 9a43cbc31d9d468f97a93853fb361a01790156bf25be26ca0672c4f775e886c4
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/matches.sync.traceability.yaml
+++ b/generated/manifests/matches.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/matches.sync.resolved.yaml
-  policy_sha256: f8c67194e47f0e86b631cc43f4728f609ac460111647c1c7c3548c6e10c46650
+  policy_sha256: 6c6058d1f57fd877877d5fd859b02e05f1b1054dfa4436801fe71607d01677bc
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/medical.sync.traceability.yaml
+++ b/generated/manifests/medical.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/medical.sync.resolved.yaml
-  policy_sha256: 3cd3046d7e2f8806415922ed6366d416d577bd6420acedd98ea8ef0094d495b0
+  policy_sha256: a60c1212ee1057921131dd9bd3d6081635bfff6ba60a2846ad914eeca0179ad6
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/notifications.event.traceability.yaml
+++ b/generated/manifests/notifications.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/notifications.event.resolved.yaml
-  policy_sha256: 16f92846fcfd187bdec133ac8490e8f32f3cb707aed245c2dfe19bb6ecea9d6b
+  policy_sha256: ccd779eeb09ef51fd3187069de1b6c862e40988f2359d7b4c7ceee3ee976e5b9
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/notifications.sync.traceability.yaml
+++ b/generated/manifests/notifications.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/notifications.sync.resolved.yaml
-  policy_sha256: ffa88ce4bda0cd4c23d1420e8480e1d75a7a6408f443315812b3e81f1ae37d9f
+  policy_sha256: 83a727131dd51a78baa63501c7bf4a400fa9e510ccfb5e9403f518d24e45c45e
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/reports.sync.traceability.yaml
+++ b/generated/manifests/reports.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/reports.sync.resolved.yaml
-  policy_sha256: b86a2168a6fcb13357e681e31e6cc84b4868a13fe305477085c34fc8b04fc553
+  policy_sha256: af2bdfc19bc3d4178ac264e891f9f92490a1e23f8bcfa988c85abc869b6f8824
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/scout.event.traceability.yaml
+++ b/generated/manifests/scout.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/scout.event.resolved.yaml
-  policy_sha256: 0abe472462b3752a7a02b564949f6b025679b4805a83244c169cf4b44eaed86e
+  policy_sha256: c37759422426321857b5af325c56136dc9da16da121c9a28dafbea0d0efd8792
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/scout.sync.traceability.yaml
+++ b/generated/manifests/scout.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/scout.sync.resolved.yaml
-  policy_sha256: f7e0d82e1bdc6b452bc09e714d6bcd5104f46724dc0da6df40727c1294748fc5
+  policy_sha256: 25b96178996244fef91b8fb2956b837b24014b8b729fed8483a96fc3c9f71013
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/seasons.event.traceability.yaml
+++ b/generated/manifests/seasons.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/seasons.event.resolved.yaml
-  policy_sha256: 421970243f0b990b4541bced90d22d6e24503974d2c9d31f78c026f7754ef562
+  policy_sha256: c916ed291807667a8c44a7f8c7ed88c332d6856d8d81c69885784e0ac0512f9d
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/seasons.sync.traceability.yaml
+++ b/generated/manifests/seasons.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/seasons.sync.resolved.yaml
-  policy_sha256: 6b6805f8f5f79874322c4aa0f93e693f9fcea7dd4641f6e1f273469cf35e5021
+  policy_sha256: b90a7508b2deae2aac07b45443e37e35f02ff7a7d2b6982dba7e1ff4e88ad033
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/teams.event.traceability.yaml
+++ b/generated/manifests/teams.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/teams.event.resolved.yaml
-  policy_sha256: b76b6cf25b4e505899d0bfd4cdc4817984b525b1f489fc0069842c54f4a5ce44
+  policy_sha256: bb887c8b11c272b0df4f22648d075ba353bdeea6766d0ed173fe1b2e983b0630
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/teams.sync.traceability.yaml
+++ b/generated/manifests/teams.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/teams.sync.resolved.yaml
-  policy_sha256: 6a659319ac6364ac21794e05e752f29670cd463c9dd907484a1cd916d235d108
+  policy_sha256: 64d646925b2dbb2cc96a4a81aa26a13df78f0feaea8de59e35d7f9ab0b8b40a1
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/training.event.traceability.yaml
+++ b/generated/manifests/training.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/training.event.resolved.yaml
-  policy_sha256: 3b24212bdbf407f50222b2e46826a8f5512627aa2e8bc6230a6db3837f9f5bc3
+  policy_sha256: 4b3aefc621da12bbb1e5d4059b6bcd0c2112b1d251a91fec174b6da2ca6cde32
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/training.sync.traceability.yaml
+++ b/generated/manifests/training.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/training.sync.resolved.yaml
-  policy_sha256: 1b8cbf1cd851c94b8eea0600c9e0ba094b8f0dee567bfb7825ff5925ff94f5de
+  policy_sha256: d3591622491ae0cc0077307298ac18eb8074d287a5cc76ac458c2047152c3a5c
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/users.event.traceability.yaml
+++ b/generated/manifests/users.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/users.event.resolved.yaml
-  policy_sha256: e91ce24b80506d16e54cbf3590011e1a34210d735fe3f819b87c519c65e50f40
+  policy_sha256: 10ae6ca9cb23331aa39015c6db26824efc07cf793f01553a4d2a773a6d393b21
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/users.sync.traceability.yaml
+++ b/generated/manifests/users.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/users.sync.resolved.yaml
-  policy_sha256: ed8a6b9202980b4e925a8b520735b97467bd60801aebb90e94335fc8883e82ee
+  policy_sha256: 7c79cffebeace077d94553e34e85ac59fc167071d70cf9df0f33e2e5fc3e1c33
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/video.event.traceability.yaml
+++ b/generated/manifests/video.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/video.event.resolved.yaml
-  policy_sha256: 11500ce506cd91e53fdea1fd16bf48a98929c781de9865a253311d6206a340c5
+  policy_sha256: 3a0ac2e06a2e32ffd56d62ed096899c9abce421bc6b92dafe4391e32454d0535
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/video.sync.traceability.yaml
+++ b/generated/manifests/video.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/video.sync.resolved.yaml
-  policy_sha256: 6cab62b797bfbbba9c751eb058f98da7db06d1cf021f17c9992ac5645e08db2c
+  policy_sha256: 283c3628bd1d16a2f4b2a97deacfae352d27c2d5a9d87591f403de0fa4a6ac5c
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/manifests/wellness.event.traceability.yaml
+++ b/generated/manifests/wellness.event.traceability.yaml
@@ -491,6 +491,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -557,9 +559,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: c99f07390171973a3535271bda30f488f7e1bff1b459d358839db3358fac0915
+  generated_tree_sha256: 04ecfc564ae18b4e1c4eb43ff4aafcefe4abd3621a6104552a2a48781702daa7
   policy_path: generated/resolved_policy/wellness.event.resolved.yaml
-  policy_sha256: 66487c5fdeb182833f4e9c0d7772e23da29d05ba5f564e76f395cdc49a34b313
+  policy_sha256: 87bd08840d60a361e67888986ce47ae7b761a0fc08ce76b595397204c4f807f9
   source_contracts:
   - path: contracts/asyncapi/README.md
     sha256: 911c379f8c48a9d804be28b64039aecb958e863762051ebcad6f0eab7b1266de
@@ -1049,6 +1051,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -1126,4 +1130,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: cf6e102680ae86287a9df9d0f2a02adbd8626a71e95c207ae86235c13c639efe
+  source_tree_sha256: 9156e45e6b9dcd790748316061fc64291ee632d98ffd8bee1d8e36473d5c9766

--- a/generated/manifests/wellness.sync.traceability.yaml
+++ b/generated/manifests/wellness.sync.traceability.yaml
@@ -255,6 +255,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: generated/contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: generated/contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: generated/contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: generated/contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -321,9 +323,9 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: f3bdc98dc1720b492b50806d25c4fd904a919c61b94bc1e968f30592f5b9873e
+  generated_tree_sha256: e8543accc3d0881f916f42dad7e04efc916d1d4108ec4122531aa1cb98e6bc4f
   policy_path: generated/resolved_policy/wellness.sync.resolved.yaml
-  policy_sha256: ff4d98976f55a78738ebfd59a3fcb91359256387158990f02b7056fd427af8cd
+  policy_sha256: b19ab3f45f14104af07fd7def936ce4cf70ac4e369d1ac874d6536d6ba5a0d2e
   source_contracts:
   - path: contracts/openapi/README.md
     sha256: ac7fe69b8b5fc9c580de4bfee6f0fa8f64822048ab6622e078f5db64e54e396f
@@ -577,6 +579,8 @@ traceability_manifest:
     sha256: d002b4c07c9b93c9763ddc31910c0562df76a7545c9427ec00e139adb92e70e8
   - path: contracts/schemas/shared/domain_axioms_module.schema.json
     sha256: c8bc89b19d5fcd019567156e0f40480efe238332df73e89aaede7314d7324a19
+  - path: contracts/schemas/shared/merge-readiness.schema.json
+    sha256: 5f78765132a99c52ce330bf271f5e6ca3757afcb14f80397267e4bfec3614a38
   - path: contracts/schemas/shared/module_registry.schema.json
     sha256: a4480665edb80aed06b3a141dcd2dec744651554d48791defa8e9bdae009e347
   - path: contracts/schemas/shared/module_source_authority_matrix.schema.json
@@ -654,4 +658,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: d7495e17090c41af465fbf064d0bff3d084c72ba0e57f1e0d78aa3b8f0ae71eb
-  source_tree_sha256: 3dae598550ac0284d658d1c52807e4ba9076095ec334986f20a6fd628324bcaa
+  source_tree_sha256: 7cc031998067e4ba4fb32b8c6a437d7e74ced232dbf71a53142faa6628a24704

--- a/generated/resolved_policy/ai_ingestion.event.resolved.yaml
+++ b/generated/resolved_policy/ai_ingestion.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/ai_ingestion.sync.resolved.yaml
+++ b/generated/resolved_policy/ai_ingestion.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/analytics.sync.resolved.yaml
+++ b/generated/resolved_policy/analytics.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/audit.event.resolved.yaml
+++ b/generated/resolved_policy/audit.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/audit.sync.resolved.yaml
+++ b/generated/resolved_policy/audit.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/competitions.event.resolved.yaml
+++ b/generated/resolved_policy/competitions.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/competitions.sync.resolved.yaml
+++ b/generated/resolved_policy/competitions.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/exercises.sync.resolved.yaml
+++ b/generated/resolved_policy/exercises.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/identity_access.event.resolved.yaml
+++ b/generated/resolved_policy/identity_access.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/identity_access.sync.resolved.yaml
+++ b/generated/resolved_policy/identity_access.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/matches.event.resolved.yaml
+++ b/generated/resolved_policy/matches.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/matches.sync.resolved.yaml
+++ b/generated/resolved_policy/matches.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/medical.sync.resolved.yaml
+++ b/generated/resolved_policy/medical.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/notifications.event.resolved.yaml
+++ b/generated/resolved_policy/notifications.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/notifications.sync.resolved.yaml
+++ b/generated/resolved_policy/notifications.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/reports.sync.resolved.yaml
+++ b/generated/resolved_policy/reports.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/scout.event.resolved.yaml
+++ b/generated/resolved_policy/scout.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/scout.sync.resolved.yaml
+++ b/generated/resolved_policy/scout.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/seasons.event.resolved.yaml
+++ b/generated/resolved_policy/seasons.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/seasons.sync.resolved.yaml
+++ b/generated/resolved_policy/seasons.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/teams.event.resolved.yaml
+++ b/generated/resolved_policy/teams.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/teams.sync.resolved.yaml
+++ b/generated/resolved_policy/teams.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/training.event.resolved.yaml
+++ b/generated/resolved_policy/training.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/training.sync.resolved.yaml
+++ b/generated/resolved_policy/training.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/users.event.resolved.yaml
+++ b/generated/resolved_policy/users.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/users.sync.resolved.yaml
+++ b/generated/resolved_policy/users.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/video.event.resolved.yaml
+++ b/generated/resolved_policy/video.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/video.sync.resolved.yaml
+++ b/generated/resolved_policy/video.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/wellness.event.resolved.yaml
+++ b/generated/resolved_policy/wellness.event.resolved.yaml
@@ -369,6 +369,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/generated/resolved_policy/wellness.sync.resolved.yaml
+++ b/generated/resolved_policy/wellness.sync.resolved.yaml
@@ -251,6 +251,7 @@ contract_sources:
 - contracts/schemas/shared/.gitkeep
 - contracts/schemas/shared/domain_axioms.schema.json
 - contracts/schemas/shared/domain_axioms_module.schema.json
+- contracts/schemas/shared/merge-readiness.schema.json
 - contracts/schemas/shared/module_registry.schema.json
 - contracts/schemas/shared/module_source_authority_matrix.schema.json
 - contracts/schemas/shared/owasp_api_control_matrix.schema.json

--- a/merge-readiness.json
+++ b/merge-readiness.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "./contracts/schemas/shared/merge-readiness.schema.json",
+    "version": "1.0.0",
+    "updated": "2026-04-03",
+    "target_branch": "main",
+    "ruleset_name": "contract-gates",
+    "ruleset_id": 13901517,
+    "checks": [
+        {
+            "context": "Validate Contract Gates",
+            "workflow": "contract-gates.yml",
+            "job": "validate-contracts",
+            "category": "required",
+            "local_equivalent": "python3 scripts/hb preflight (STEP 3)"
+        },
+        {
+            "context": "Governance Tests",
+            "workflow": "contract-gates.yml",
+            "job": "governance-tests",
+            "category": "required",
+            "local_equivalent": "pytest tests/test_pipeline_governance.py"
+        },
+        {
+            "context": "Architecture Drift Check",
+            "workflow": "contract-gates.yml",
+            "job": "architecture-drift-check",
+            "category": "required",
+            "local_equivalent": "python3 scripts/audit/check_architecture_docs.py --json && pytest tests/pipeline_gates/test_architecture_drift.py"
+        },
+        {
+            "context": "Validate Contracts",
+            "workflow": "ci.yml",
+            "job": "validate",
+            "category": "required",
+            "local_equivalent": "python3 scripts/contracts/validate/validate_contracts.py"
+        },
+        {
+            "context": "Tests",
+            "workflow": "ci.yml",
+            "job": "test",
+            "category": "required",
+            "local_equivalent": "pytest -q"
+        },
+        {
+            "context": "Frontend Build + Tests",
+            "workflow": "ci.yml",
+            "job": "build-frontend",
+            "category": "required",
+            "local_equivalent": "npm --prefix frontend ci && npm --prefix frontend run build && npm --prefix frontend test"
+        },
+        {
+            "context": "Docker Build Check",
+            "workflow": "ci.yml",
+            "job": "build",
+            "category": "informational",
+            "reason": "Valida Dockerfile mas não bloqueia merge — falha de build de imagem não impede integração de código"
+        },
+        {
+            "context": "Governance Enforcement (survival-suite)",
+            "workflow": "contract-gates.yml",
+            "job": "governance-enforcement",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — só roda quando arquivos de governança (.contract_driven/, contracts/, docs/_canon/) são modificados"
+        },
+        {
+            "context": "Paridade Registry × Executor",
+            "workflow": "contract-gates.yml",
+            "job": "registry-executor-parity",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — verifica paridade entre MODULE_REGISTRY.yaml e executores; ativado apenas em mudanças de governança"
+        },
+        {
+            "context": "Paridade Schema × Template × Skills",
+            "workflow": "contract-gates.yml",
+            "job": "schema-template-skills-parity",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — verifica paridade entre schemas, templates e skills; ativado apenas em mudanças de governança"
+        },
+        {
+            "context": "Validação Cruzada SESSION_HANDOFF ↔ session_start",
+            "workflow": "contract-gates.yml",
+            "job": "session-handoff-crossval",
+            "category": "conditional",
+            "condition": "governance_changed == true",
+            "reason": "Condicional — cross-valida SESSION_HANDOFF.md contra session_start workflow; ativado apenas em mudanças de governança"
+        }
+    ],
+    "enforcement": {
+        "require_pr": true,
+        "require_conversation_resolution": true,
+        "require_up_to_date": true,
+        "block_force_push": true,
+        "block_deletion": true,
+        "bypass_actors": []
+    },
+    "local_executor": {
+        "command": "python3 scripts/hb preflight",
+        "evidence_path": "_reports/preflight/latest.json",
+        "pre_push_hook": "scripts/git-hooks/pre-push"
+    }
+}


### PR DESCRIPTION
## Entregável 3 — Manifesto canônico de merge-readiness

> Parte do `PLAN_EXEC_PARIDADE.md`. Sequência: E1 (#31 ✅) → E2 (#32 ✅) → **E3 (este PR)** → E4 → E5 → E6

Substitui PR #33 (branch contaminado `parity/merge-readiness`).

### Arquivos criados (diff mínimo — 3 arquivos)

| Arquivo | Propósito |
|---|---|
| `merge-readiness.json` | SSOT dos checks de merge — 6 required, 1 informational, 4 conditional |
| `contracts/schemas/shared/merge-readiness.schema.json` | JSON Schema Draft-2020-12 com `allOf/if/then` por categoria |
| `generated/contracts/schemas/shared/merge-readiness.schema.json` | Artefato derivado |

### Checks required (6 — estado atual do ruleset 13901517)

| Context | Executor local |
|---|---|
| Validate Contract Gates | `python3 scripts/hb preflight (STEP 3)` |
| Governance Tests | `pytest tests/test_pipeline_governance.py` |
| Architecture Drift Check | `python3 scripts/audit/check_architecture_docs.py --json && pytest tests/pipeline_gates/test_architecture_drift.py` |
| Validate Contracts | `python3 scripts/contracts/validate/validate_contracts.py` |
| Tests | `pytest -q` |
| Frontend Build + Tests | `npm --prefix frontend ci && npm --prefix frontend run build && npm --prefix frontend test` |

### Critério de done

- [ ] CI verde (6 required checks)
- [ ] `merge-readiness.json` válido contra schema
- [ ] Todo `required` tem `local_equivalent`
- [ ] Todo `conditional` tem `condition + reason`
- [ ] Contexts batem com ruleset API (case-sensitive, sem prefixo `CI /`)