### PR TITLE
fix(parity/E5): hb ci — hooksPath + HB_RUN_SCHEMATHESIS por perfil

### DIFF
--- a/scripts/hb
+++ b/scripts/hb
@@ -898,11 +898,16 @@ class HBCLIv2:
           full — pytest -v --tb=short                (cobertura completa)
         """
         print(f"\n══ CI LOCAL — perfil: {profile} ══")
+        subprocess.run(
+            ["git", "config", "core.hooksPath", "scripts/git-hooks"],
+            cwd=self.root, capture_output=True,
+        )
         env = {**os.environ, **self._ci_test_env}
 
         if profile == "pr":
             cmd = [sys.executable, "-m", "pytest", "-q", "-m", "not slow", "--tb=short"]
         elif profile == "full":
+            env["HB_RUN_SCHEMATHESIS"] = "1"
             cmd = [sys.executable, "-m", "pytest", "-v", "--tb=short"]
         else:
             print(f"❌ Perfil desconhecido: {profile!r}. Use 'pr' ou 'full'.", file=sys.stderr)


### PR DESCRIPTION
Fixes P1 e P2 levantados no code review do PR-5 (#36).

**P2** — `cmd_ci()` agora configura `core.hooksPath` antes de rodar pytest, alinhando com o CI (evita falha em `TestHookIntegrity::test_hook_git_config_set` em clones frescos).

**P1** — `HB_RUN_SCHEMATHESIS` controlado por perfil:
- `pr` → `"0"` (rápido, sem Schemathesis)
- `full` → `"1"` (paridade total com CI)

> Commit cherry-picked de `parity/canonical-executor@9a7cd731`