### PR TITLE
chore(handoff): restaura branch_ativo=main após merge PR #41

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-04-04"
-branch_ativo: chore/normalize-handoff-seasons
+branch_ativo: main
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: seasons


### PR DESCRIPTION
Ajuste de 1 campo: `branch_ativo: chore/normalize-handoff-seasons` → `branch_ativo: main`.
Necessário após merge do PR #41 para manter coerência do SESSION_HANDOFF no main.