### PR TITLE
feat(matches): B10-001 — módulo matches (source graph, 6 endpoints, FT-035)

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,66 +1,64 @@
 ---
 data_ultima_sessao: "2026-04-04"
-branch_ativo: feat/b10-001-users
+branch_ativo: feat/b10-001-matches
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
-modulo_foco: users
+modulo_foco: matches
 fase_roadmap: 5
 task_type: execute_roadmap_phase
 boot_profile_id: roadmap_execution
-task_id: B10-001-users
+task_id: B10-001-matches
 resultado: DONE
-proxima_acao_permitida: "B10-001/users CONCLUÍDO — commit + push + PR → main. Próximo módulo: matches (B10-001 posição 12)."
+proxima_acao_permitida: "B10-001/matches CONCLUÍDO — commit + push + PR → main. Próximo módulo: training (B10-001 posição 13)."
 bloqueios_ativos: []
 evidence_paths:
   - _reports/contract_gates/latest.json
-  - docs/hbtrack/modulos/users/graph/module_manifest.yaml
-  - docs/hbtrack/modulos/users/graph/entities.yaml
-  - docs/hbtrack/modulos/users/graph/endpoints.yaml
-  - docs/hbtrack/modulos/users/graph/errors.yaml
-  - docs/hbtrack/modulos/users/graph/test_obligations.yaml
-  - generated/source_graph/users/users.bundle.yaml
-  - generated/source_graph/users/users.openapi_contract_view.yaml
-  - generated/source_graph/users/users.schema_contract_view.yaml
-  - generated/source_graph/users/impact_report.json
-  - compiled_context/users/FT-014.json
-  - compiled_context/users/FT-015.json
-  - compiled_context/users/FT-016.json
-  - compiled_context/users/FT-017.json
+  - docs/hbtrack/modulos/matches/graph/module_manifest.yaml
+  - docs/hbtrack/modulos/matches/graph/entities.yaml
+  - docs/hbtrack/modulos/matches/graph/endpoints.yaml
+  - docs/hbtrack/modulos/matches/graph/errors.yaml
+  - docs/hbtrack/modulos/matches/graph/test_obligations.yaml
+  - generated/source_graph/matches/matches.bundle.yaml
+  - generated/source_graph/matches/matches.openapi_contract_view.yaml
+  - generated/source_graph/matches/matches.schema_contract_view.yaml
+  - generated/source_graph/matches/impact_report.json
+  - compiled_context/matches/FT-035.json
 ---
 # SESSION HANDOFF — HB TRACK
 > Delta-only. Histórico em `_archive/SESSION_HANDOFF_PRE_FASE0_20260323.md`
 
 ## Estado Geral
-**Data:** 2026-04-04 | **Branch:** feat/b10-001-users | **CI:** em progresso (gates pré-existentes com FAIL independentes desta sessão)
-**Modo:** ROADMAP | **Fase:** B10-001 | **Resultado:** DONE — módulo `users`
+**Data:** 2026-04-04 | **Branch:** feat/b10-001-matches | **CI:** em progresso (gates pré-existentes com FAIL independentes desta sessão)
+**Modo:** ROADMAP | **Fase:** B10-001 | **Resultado:** DONE — módulo `matches`
 
-## O que foi feito nesta sessão (B10-001 / users)
+## O que foi feito nesta sessão (B10-001 / matches)
 
-Base: feat/b10-001-competitions (branch de trabalho)
+Base: feat/b10-001-users (branch de trabalho)
 
-1. **Source graph** (`docs/hbtrack/modulos/users/graph/`): 5 YAMLs — module_manifest, entities (UserProfile/12 campos), endpoints (4: listUsers/createUser/getUser/patchUser), errors (8 entradas), test_obligations (USR-TO-001..004)
-2. `compile_source_graph.py --module users` → PASS (4 artefatos)
-3. `compile_source_graph.py --all --check` → PASS (5 módulos: audit, competitions, seasons, teams, users)
-4. `USERS_SOURCE_GRAPH_SYNC` adicionado ao SYNC_MANIFEST
-5. `HBTRACK_USERS_GRAPH` adicionado ao DOC_USAGE_MANIFEST
-6. `compile_context_bundle.py --module users` → PASS (FT-014, FT-015, FT-016, FT-017)
-7. `compile_context_bundle.py --all` → PASS (5 módulos)
-8. Docs atualizados: README, DOMAIN_RULES_USERS, TEST_MATRIX_USERS (seção Source Graph e TM-005)
-9. 3 arquivos de teste criados — **16 testes PASS** (integrity, compiler, context_bundle)
+1. **Fix FEATURE_REGISTRY**: endpoints FT-035 corrigidos — POST /matches/{matchId}/lineup/{userId} → PUT; adicionados PATCH /matches/{matchId} e DELETE /matches/{matchId}/lineup/{userId}
+2. **Source graph** (`docs/hbtrack/modulos/matches/graph/`): 5 YAMLs — module_manifest, entities/Match/16 campos, endpoints/6 ops, errors/6 entradas, test_obligations/MATCH-TO-001..004
+3. `compile_source_graph.py --module matches` → PASS (4 artefatos)
+4. `compile_source_graph.py --all --check` → PASS (6 módulos: audit, competitions, matches, seasons, teams, users)
+5. `MATCHES_SOURCE_GRAPH_SYNC` adicionado ao SYNC_MANIFEST
+6. `HBTRACK_MATCHES_GRAPH` adicionado ao DOC_USAGE_MANIFEST
+7. `compile_context_bundle.py --module matches` → PASS (FT-035)
+8. `compile_context_bundle.py --all` → PASS (6 módulos)
+9. Docs atualizados: README, DOMAIN_RULES_MATCHES, TEST_MATRIX_MATCHES (seção Source Graph, TM-005)
+10. 3 arquivos de teste criados — **16 testes PASS** (integrity, compiler, context_bundle)
 
 ## Próxima ação permitida
 
-B10-001/users — commit + push + PR → main. Depois: iniciar B10-001/matches (posição 12).
+B10-001/matches — commit + push + PR → main. Depois: iniciar B10-001/training (posição 13).
 
 Gates pré-existentes com FAIL (não introduzidos nesta sessão, presentes em main):
 - SHADOW_AUTHORITY_GATE: documento não-soberano sem disclaimer (pré-existente)
 - DERIVED_DRIFT_GATE: hash divergente em merge-readiness.schema.json (pré-existente)
 
 ## Evidências geradas
-- `docs/hbtrack/modulos/users/graph/` — 5 YAMLs (source graph)
-- `generated/source_graph/users/` — 4 artefatos compilados
-- `compiled_context/users/FT-014..017.json` — 4 context bundles
-- `tests/pipeline_gates/test_users_*.py` — 16 testes PASS
+- `docs/hbtrack/modulos/matches/graph/` — 5 YAMLs (source graph)
+- `generated/source_graph/matches/` — 4 artefatos compilados
+- `compiled_context/matches/FT-035.json` — 1 context bundle
+- `tests/pipeline_gates/test_matches_*.py` — 16 testes PASS
 
 ## Bloqueios ativos
 Nenhum.

--- a/_reports/contract_gates/precommit.latest.json
+++ b/_reports/contract_gates/precommit.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-04T20:06:32Z",
+  "timestamp_utc": "2026-04-04T21:34:59Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "c470fa9d",
+    "git_commit": "314819b7",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,7 +31,7 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/precommit.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260404T200632_7e25f1"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260404T213459_c13333"
   },
   "status_detail": {
     "active_gates_passed": 23,
@@ -229,7 +229,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 51
+        "duration_ms": 45
       }
     },
     {
@@ -254,7 +254,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4459
+        "duration_ms": 8036
       }
     },
     {
@@ -365,7 +365,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 19
+        "duration_ms": 20
       }
     },
     {
@@ -616,7 +616,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4
+        "duration_ms": 6
       }
     },
     {
@@ -988,7 +988,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 95
+        "duration_ms": 91
       }
     },
     {
@@ -1074,7 +1074,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 948
+        "duration_ms": 1008
       }
     },
     {
@@ -1097,7 +1097,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3609
+        "duration_ms": 3153
       }
     },
     {
@@ -1119,7 +1119,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2470
+        "duration_ms": 3548
       }
     },
     {
@@ -1158,7 +1158,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 687
+        "duration_ms": 943
       }
     },
     {
@@ -1198,7 +1198,7 @@
         "errors": 0,
         "warnings": 1,
         "violations": 1,
-        "duration_ms": 1854
+        "duration_ms": 2967
       }
     },
     {
@@ -1766,6 +1766,12 @@
         "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/PERMISSIONS_USERS.md",
         "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/README.md",
         "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/TEST_MATRIX_USERS.md",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/endpoints.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/entities.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/errors.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/module_manifest.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/test_obligations.yaml",
         "/home/davis/HB-TRACK/docs/hbtrack/modulos/video",
         "/home/davis/HB-TRACK/docs/hbtrack/modulos/video/DOMAIN_RULES_VIDEO.md",
         "/home/davis/HB-TRACK/docs/hbtrack/modulos/video/INVARIANTS_VIDEO.md",
@@ -1789,7 +1795,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2095
+        "duration_ms": 2003
       }
     },
     {
@@ -1865,7 +1871,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2802
+        "duration_ms": 2385
       }
     },
     {
@@ -1930,7 +1936,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1177
+        "duration_ms": 1131
       }
     },
     {
@@ -1986,7 +1992,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 73
+        "duration_ms": 67
       }
     },
     {
@@ -2006,7 +2012,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 4
       }
     },
     {
@@ -2182,31 +2188,37 @@
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/module_manifest.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/entities.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/endpoints.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/errors.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/test_obligations.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/competitions.bundle.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/competitions.openapi_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/competitions.schema_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/impact_report.json",
-        "/home/davis/HB-TRACK/compiled_context/competitions/FT-034.json"
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/module_manifest.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/entities.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/endpoints.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/errors.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/test_obligations.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.bundle.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.openapi_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.schema_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/impact_report.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-014.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-015.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-016.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-017.json"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/module_manifest.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/entities.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/endpoints.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/errors.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/competitions/graph/test_obligations.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/competitions.bundle.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/competitions.openapi_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/competitions.schema_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/competitions/impact_report.json",
-        "/home/davis/HB-TRACK/compiled_context/competitions/FT-034.json"
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/module_manifest.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/entities.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/endpoints.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/errors.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/test_obligations.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.bundle.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.openapi_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.schema_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/users/impact_report.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-014.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-015.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-016.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-017.json"
       ],
       "evidence_files": [],
       "violations": [],
@@ -2214,7 +2226,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 16
+        "duration_ms": 28
       }
     },
     {
@@ -2236,7 +2248,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 214
+        "duration_ms": 209
       }
     },
     {
@@ -2340,7 +2352,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 24
+        "duration_ms": 26
       }
     },
     {
@@ -2358,7 +2370,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 8
+        "duration_ms": 7
       }
     },
     {

--- a/_reports/contract_gates/stage-session-start.local.latest.json
+++ b/_reports/contract_gates/stage-session-start.local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-04T21:24:52Z",
+  "timestamp_utc": "2026-04-04T22:00:31Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "314819b7",
+    "git_commit": "4b2608ce",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,7 +31,7 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-session-start.local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260404T212452_4ec135"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260404T220031_ba7161"
   },
   "status_detail": {
     "active_gates_passed": 4,
@@ -229,7 +229,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 141
+        "duration_ms": 330
       }
     },
     {
@@ -981,37 +981,31 @@
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/module_manifest.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/entities.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/endpoints.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/errors.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/test_obligations.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/users.bundle.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/users.openapi_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/users.schema_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/impact_report.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-014.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-015.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-016.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-017.json"
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/module_manifest.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/entities.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/endpoints.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/errors.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/test_obligations.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/matches.bundle.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/matches.openapi_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/matches.schema_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/impact_report.json",
+        "/home/davis/HB-TRACK/compiled_context/matches/FT-035.json"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/module_manifest.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/entities.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/endpoints.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/errors.yaml",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/users/graph/test_obligations.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/users.bundle.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/users.openapi_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/users.schema_contract_view.yaml",
-        "/home/davis/HB-TRACK/generated/source_graph/users/impact_report.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-014.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-015.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-016.json",
-        "/home/davis/HB-TRACK/compiled_context/users/FT-017.json"
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/module_manifest.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/entities.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/endpoints.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/errors.yaml",
+        "/home/davis/HB-TRACK/docs/hbtrack/modulos/matches/graph/test_obligations.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/matches.bundle.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/matches.openapi_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/matches.schema_contract_view.yaml",
+        "/home/davis/HB-TRACK/generated/source_graph/matches/impact_report.json",
+        "/home/davis/HB-TRACK/compiled_context/matches/FT-035.json"
       ],
       "evidence_files": [],
       "violations": [],
@@ -1019,7 +1013,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 50
+        "duration_ms": 36
       }
     },
     {
@@ -1041,7 +1035,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 299
+        "duration_ms": 367
       }
     },
     {

--- a/_reports/session_start.json
+++ b/_reports/session_start.json
@@ -1,11 +1,11 @@
 {
   "session_id": "6002b3ea-1160-4b93-b4b7-1950a5d628c4",
-  "session_timestamp": "2026-04-04T21:24:51.817084+00:00",
-  "branch": "feat/b10-001-users",
+  "session_timestamp": "2026-04-04T22:00:30.410881+00:00",
+  "branch": "feat/b10-001-matches",
   "pipeline_version": "1.0.0",
   "boot_profile_id": "roadmap_execution",
   "task_type": "execute_roadmap_phase",
-  "stage": 2,
+  "stage": 0,
   "write_scope": "roadmap",
   "worker_id": "execute_roadmap_phase",
   "git_user": "HB Track Agent",
@@ -387,5 +387,5 @@
   ],
   "stage2_exit_code": 0,
   "hook_exit_code": 0,
-  "hook_validated_at": "2026-04-04T20:06:55.127212+00:00"
+  "hook_validated_at": "2026-04-04T21:35:27.453347+00:00"
 }

--- a/compiled_context/audit/FT-041.json
+++ b/compiled_context/audit/FT-041.json
@@ -77,7 +77,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -89,7 +89,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/audit/audit.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/audit/domain/rules.py",
     "use_cases": "src/audit/application/use_cases.py"
   },
-  "source_fingerprint": "54b29a8ed56a4849a28f11a1a8f355979d156511b8c5a4b9d80151278e09f6e9",
+  "source_fingerprint": "da55e40c3ba5b575614ce0264f92be213f0c4c5e4502959af39f31e32626549c",
   "source_graph": {
     "entities": {
       "AuditEntry": {

--- a/compiled_context/competitions/FT-034.json
+++ b/compiled_context/competitions/FT-034.json
@@ -77,7 +77,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -89,7 +89,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/competitions/competitions.bundle.yaml",
@@ -135,7 +135,7 @@
     "domain_rules": "src/competitions/domain/rules.py",
     "use_cases": "src/competitions/application/use_cases.py"
   },
-  "source_fingerprint": "881f1f60e9e06bb3f87df4eb4420bb6151b036549ea8ccac6577ada69eaea010",
+  "source_fingerprint": "caf1e2f2686e416214229bd733841d883202d4202c15d7ceafdea846dfd22277",
   "source_graph": {
     "entities": {
       "Competition": {

--- a/compiled_context/matches/FT-035.json
+++ b/compiled_context/matches/FT-035.json
@@ -1,0 +1,1334 @@
+{
+  "artifact_id": "HBTRACK_MODULE_FEATURE_CONTEXT_BUNDLE",
+  "authority": {
+    "openapi_contract_view_ref": "generated/source_graph/matches/matches.openapi_contract_view.yaml",
+    "partial_update_policy": "blocked",
+    "precedence_order": [
+      "enforcement_executable",
+      "active_schemas",
+      "source_authority_graph",
+      "concept_owner_source",
+      "bridge_docs",
+      "derived_artifacts",
+      "legacy_or_study"
+    ],
+    "schema_contract_view_ref": "generated/source_graph/matches/matches.schema_contract_view.yaml",
+    "source_authority_graph_ref": "docs/_canon/SOURCE_AUTHORITY_GRAPH.yaml",
+    "source_graph_bundle_ref": "generated/source_graph/matches/matches.bundle.yaml",
+    "source_graph_impact_ref": "generated/source_graph/matches/impact_report.json",
+    "sync_manifest_ref": "docs/_canon/SYNC_MANIFEST.yaml",
+    "sync_rule_id": "MATCHES_SOURCE_GRAPH_SYNC"
+  },
+  "compiler": "hbtrack_context_bundle_compiler",
+  "compiler_version": "0.1.0",
+  "contract_surfaces": {
+    "openapi_paths": "contracts/openapi/paths/matches.yaml",
+    "openapi_projection": "contracts/openapi/components/schemas/matches/match.yaml",
+    "primary_schema": "contracts/schemas/matches/match.schema.json",
+    "sovereign_schema_dir": "contracts/schemas/matches"
+  },
+  "feature": {
+    "contracts": [
+      "contracts/openapi/paths/matches.yaml"
+    ],
+    "description": "Admin e coordenador agendam partidas entre equipes e registram as escalações (lineup) dos jogadores convocados.",
+    "endpoints": [
+      "GET /matches",
+      "POST /matches",
+      "GET /matches/{matchId}",
+      "PATCH /matches/{matchId}",
+      "PUT /matches/{matchId}/lineup/{userId}",
+      "DELETE /matches/{matchId}/lineup/{userId}"
+    ],
+    "id": "FT-035",
+    "name": "Agendar Partidas e Gerenciar Escalações",
+    "slug": "agendar-partidas-e-gerenciar-escalações",
+    "status": "implemented"
+  },
+  "implementation_targets": {
+    "canonical_runtime": [
+      "src/matches/api.py",
+      "src/matches/application/use_cases.py",
+      "src/matches/domain/entities.py",
+      "src/matches/domain/rules.py",
+      "src/matches/schemas.py"
+    ],
+    "contracts": [
+      "contracts/openapi/components/schemas/matches/match.yaml",
+      "contracts/openapi/paths/matches.yaml",
+      "contracts/schemas/matches/match.schema.json"
+    ],
+    "derived_context": [
+      "compiled_context/matches/FT-035.json"
+    ],
+    "generated_runtime": [],
+    "module_docs": [
+      "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md",
+      "docs/hbtrack/modulos/matches/INVARIANTS_MATCHES.md",
+      "docs/hbtrack/modulos/matches/MODULE_SCOPE_MATCHES.md",
+      "docs/hbtrack/modulos/matches/PERMISSIONS_MATCHES.md",
+      "docs/hbtrack/modulos/matches/README.md",
+      "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md"
+    ],
+    "tests": [
+      "tests/pipeline_gates/test_context_bundle_matches.py",
+      "tests/pipeline_gates/test_matches_source_graph_integrity.py",
+      "tests/pipeline_gates/test_source_graph_compiler_matches.py"
+    ]
+  },
+  "inputs": [
+    {
+      "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
+    },
+    {
+      "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
+      "sha256": "0f22b477ffaf2dec13c77adc469fd21cbbbf2fd2d6d1d5d6fcf672039972fedd"
+    },
+    {
+      "relpath": "docs/_canon/SOURCE_AUTHORITY_GRAPH.yaml",
+      "sha256": "c7ff89bb7bc4e0e1851a3e6b1fd0aeaefbb0a0d5cdfb6a71aad0becfe042d8d1"
+    },
+    {
+      "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
+    },
+    {
+      "relpath": "generated/source_graph/matches/matches.bundle.yaml",
+      "sha256": "60708d4575b85209671785c6cf73e46ee7add562f42aa6040b068c3d0d4cbb54"
+    },
+    {
+      "relpath": "generated/source_graph/matches/matches.schema_contract_view.yaml",
+      "sha256": "7d376b7b0dd473f4dabad9ea6f4dda26162d7efb3f5e5fb35d8f6adae62955e1"
+    },
+    {
+      "relpath": "generated/source_graph/matches/matches.openapi_contract_view.yaml",
+      "sha256": "19143242ed11b9f028305c40c0076521a502482627ad93ec1ea8d48922ab3167"
+    },
+    {
+      "relpath": "generated/source_graph/matches/impact_report.json",
+      "sha256": "973b66b1ccc2d0f412b5696e7d1d4f74ad889acbc2d294e0f7b07e1b9f5e6b12"
+    }
+  ],
+  "module": "matches",
+  "module_docs": {
+    "domain_rules": "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md",
+    "invariants": "docs/hbtrack/modulos/matches/INVARIANTS_MATCHES.md",
+    "permissions": "docs/hbtrack/modulos/matches/PERMISSIONS_MATCHES.md",
+    "readme": "docs/hbtrack/modulos/matches/README.md",
+    "scope": "docs/hbtrack/modulos/matches/MODULE_SCOPE_MATCHES.md",
+    "test_matrix": "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md"
+  },
+  "module_state": {
+    "expected_surfaces": [
+      "module_docs_minimum",
+      "openapi_sync",
+      "json_schema",
+      "test_matrix",
+      "asyncapi",
+      "arazzo"
+    ],
+    "owner": "handball-ops",
+    "status": "implemented"
+  },
+  "runtime_surfaces": {
+    "api_router": "src/matches/api.py",
+    "domain_entity": "src/matches/domain/entities.py",
+    "domain_rules": "src/matches/domain/rules.py",
+    "use_cases": "src/matches/application/use_cases.py"
+  },
+  "source_fingerprint": "006dfed69366dfc2f5314ae2e442517da426b000671f3b47a714b6f070824efa",
+  "source_graph": {
+    "entities": {
+      "Match": {
+        "docs_refs": [
+          "../DOMAIN_RULES_MATCHES.md",
+          "../INVARIANTS_MATCHES.md",
+          "../PERMISSIONS_MATCHES.md"
+        ],
+        "domain_enums": [
+          {
+            "name": "RoleLabel",
+            "source": "ADR-008 / SYSTEM_SCOPE.md",
+            "values": [
+              "admin",
+              "coordinator",
+              "coach",
+              "athlete",
+              "member"
+            ]
+          },
+          {
+            "name": "MatchStatus",
+            "source": "DEC-MATCHES-002 / HBR-013",
+            "values": [
+              "SCHEDULED",
+              "PRE_MATCH",
+              "FIRST_HALF",
+              "HALF_TIME",
+              "SECOND_HALF",
+              "OVERTIME_1",
+              "OVERTIME_2",
+              "PENALTIES",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          }
+        ],
+        "invariants": [
+          {
+            "id": "INV-MATCH-001",
+            "rule": "id, competition_id, home_team_id, away_team_id, scheduled_at são obrigatórios."
+          },
+          {
+            "id": "INV-MATCH-002",
+            "rule": "home_team_id deve ser diferente de away_team_id."
+          },
+          {
+            "id": "INV-MATCH-003",
+            "rule": "home_score e away_score devem ser >= 0 quando presentes."
+          },
+          {
+            "id": "INV-MATCH-004",
+            "rule": "started_at deve ser <= ended_at quando ambos presentes."
+          },
+          {
+            "id": "INV-MATCH-005",
+            "rule": "lineup_user_ids, official_incident_ids e referee_names não podem ter duplicatas."
+          }
+        ],
+        "runtime_entity_ref": "../../../../../src/matches/domain/entities.py#Match",
+        "schema_ref": "../../../../../contracts/schemas/matches/match.schema.json",
+        "sovereign_fields": [
+          {
+            "name": "id",
+            "required": true,
+            "runtime_name": "id",
+            "type": "uuid_v4"
+          },
+          {
+            "constraints": [
+              "DR-MATCH-001: matches é soberano do registro oficial; competitionId é obrigatório",
+              "INV-MATCH-001: campo obrigatório",
+              "boundary: reference to competitions module"
+            ],
+            "name": "competitionId",
+            "required": true,
+            "runtime_name": "competition_id",
+            "type": "uuid_v4"
+          },
+          {
+            "constraints": [
+              "DR-MATCH-002: equipe mandante",
+              "INV-MATCH-001: campo obrigatório",
+              "INV-MATCH-002: homeTeamId != awayTeamId",
+              "boundary: reference to teams module"
+            ],
+            "name": "homeTeamId",
+            "required": true,
+            "runtime_name": "home_team_id",
+            "type": "uuid_v4"
+          },
+          {
+            "constraints": [
+              "DR-MATCH-002: equipe visitante",
+              "INV-MATCH-001: campo obrigatório",
+              "INV-MATCH-002: homeTeamId != awayTeamId",
+              "boundary: reference to teams module"
+            ],
+            "name": "awayTeamId",
+            "required": true,
+            "runtime_name": "away_team_id",
+            "type": "uuid_v4"
+          },
+          {
+            "constraints": [
+              "nullable: true",
+              "maxLength: 200"
+            ],
+            "name": "venueLabel",
+            "required": false,
+            "runtime_name": "venue_label",
+            "type": "string"
+          },
+          {
+            "constraints": [
+              "DEC-MATCHES-002: 10 fases do ciclo de vida HBR-013",
+              "default: SCHEDULED na criação"
+            ],
+            "name": "statusLabel",
+            "required": true,
+            "runtime_name": "status_label",
+            "type": "enum",
+            "values": [
+              "SCHEDULED",
+              "PRE_MATCH",
+              "FIRST_HALF",
+              "HALF_TIME",
+              "SECOND_HALF",
+              "OVERTIME_1",
+              "OVERTIME_2",
+              "PENALTIES",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          {
+            "constraints": [
+              "INV-MATCH-001: campo obrigatório"
+            ],
+            "name": "scheduledAt",
+            "required": true,
+            "runtime_name": "scheduled_at",
+            "type": "datetime"
+          },
+          {
+            "constraints": [
+              "nullable: true",
+              "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+            ],
+            "name": "startedAt",
+            "required": false,
+            "runtime_name": "started_at",
+            "type": "datetime"
+          },
+          {
+            "constraints": [
+              "nullable: true",
+              "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+            ],
+            "name": "endedAt",
+            "required": false,
+            "runtime_name": "ended_at",
+            "type": "datetime"
+          },
+          {
+            "constraints": [
+              "nullable: true",
+              "minimum: 0",
+              "INV-MATCH-003: homeScore >= 0 quando presente"
+            ],
+            "name": "homeScore",
+            "required": false,
+            "runtime_name": "home_score",
+            "type": "integer"
+          },
+          {
+            "constraints": [
+              "nullable: true",
+              "minimum: 0",
+              "INV-MATCH-003: awayScore >= 0 quando presente"
+            ],
+            "name": "awayScore",
+            "required": false,
+            "runtime_name": "away_score",
+            "type": "integer"
+          },
+          {
+            "constraints": [
+              "uniqueItems: true",
+              "INV-MATCH-005: sem duplicatas",
+              "HBR-008: max 16 por equipe",
+              "boundary: reference to users module"
+            ],
+            "name": "lineupUserIds",
+            "required": true,
+            "runtime_name": "lineup_user_ids",
+            "type": "array_of_uuid"
+          },
+          {
+            "constraints": [
+              "uniqueItems: true",
+              "INV-MATCH-005: sem duplicatas",
+              "DEC-MATCHES-001: CRUD simples; súmula alimentada pelo operador pós-jogo"
+            ],
+            "name": "officialIncidentIds",
+            "required": true,
+            "runtime_name": "official_incident_ids",
+            "type": "array_of_uuid"
+          },
+          {
+            "constraints": [
+              "uniqueItems: true",
+              "INV-MATCH-005: sem duplicatas",
+              "DR-MATCH-003: árbitros são nomes simples, não entidades do domínio"
+            ],
+            "name": "refereeNames",
+            "required": true,
+            "runtime_name": "referee_names",
+            "type": "array_of_string"
+          },
+          {
+            "name": "createdAt",
+            "required": true,
+            "runtime_name": "created_at",
+            "type": "datetime"
+          },
+          {
+            "name": "updatedAt",
+            "required": true,
+            "runtime_name": "updated_at",
+            "type": "datetime"
+          }
+        ]
+      }
+    },
+    "errors": [
+      {
+        "http_status": 401,
+        "id": "ERR-MATCH-401-UNAUTHENTICATED",
+        "kind": "transport",
+        "operations": [
+          "listMatches",
+          "createMatch",
+          "getMatch",
+          "patchMatch",
+          "addPlayerToLineup",
+          "removePlayerFromLineup"
+        ],
+        "source_ref": "../../../../../src/matches/api.py#_role"
+      },
+      {
+        "exception_ref": "../../../../../src/matches/domain/rules.py#InsufficientPrivilege",
+        "http_status": 403,
+        "id": "ERR-MATCH-403-INSUFFICIENT-PRIVILEGE",
+        "kind": "domain",
+        "operations": [
+          "createMatch",
+          "patchMatch",
+          "addPlayerToLineup",
+          "removePlayerFromLineup"
+        ]
+      },
+      {
+        "exception_ref": "../../../../../src/matches/domain/rules.py#MatchNotFound",
+        "http_status": 404,
+        "id": "ERR-MATCH-404-NOT-FOUND",
+        "kind": "domain",
+        "operations": [
+          "getMatch",
+          "patchMatch",
+          "addPlayerToLineup",
+          "removePlayerFromLineup"
+        ]
+      },
+      {
+        "http_status": 400,
+        "id": "ERR-MATCH-400-VALIDATION",
+        "kind": "domain",
+        "operations": [
+          "createMatch",
+          "patchMatch"
+        ],
+        "source_ref": "../../../../../src/matches/domain/entities.py#validate_invariants"
+      },
+      {
+        "exception_ref": "../../../../../src/matches/domain/rules.py#MatchStateError",
+        "http_status": 409,
+        "id": "ERR-MATCH-409-STATE-ERROR",
+        "kind": "domain",
+        "operations": [
+          "createMatch",
+          "patchMatch",
+          "addPlayerToLineup",
+          "removePlayerFromLineup"
+        ]
+      },
+      {
+        "http_status": 500,
+        "id": "ERR-MATCH-500-INTERNAL",
+        "kind": "transport",
+        "operations": [
+          "listMatches",
+          "createMatch",
+          "getMatch",
+          "patchMatch",
+          "addPlayerToLineup",
+          "removePlayerFromLineup"
+        ],
+        "source_ref": "../../../../../src/matches/api.py#list_matches"
+      }
+    ],
+    "impact_report": {
+      "blocked_partial_update": true,
+      "impacted_contracts": [
+        "contracts/openapi/paths/matches.yaml",
+        "contracts/schemas/matches/match.schema.json",
+        "contracts/openapi/components/schemas/matches/match.yaml"
+      ],
+      "impacted_docs": [
+        "docs/hbtrack/modulos/matches/README.md",
+        "docs/hbtrack/modulos/matches/MODULE_SCOPE_MATCHES.md",
+        "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md",
+        "docs/hbtrack/modulos/matches/INVARIANTS_MATCHES.md",
+        "docs/hbtrack/modulos/matches/PERMISSIONS_MATCHES.md",
+        "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md"
+      ],
+      "impacted_runtime": [
+        "src/matches/api.py",
+        "src/matches/domain/entities.py",
+        "src/matches/domain/rules.py",
+        "src/matches/application/use_cases.py"
+      ],
+      "known_gaps": [
+        "AsyncAPI/Arazzo do módulo seguem governança separada e não estão incluídos nesta fase do source graph.",
+        "competitionId é referência cruzada para módulo competitions — boundary explicitado em DR-MATCH-001.",
+        "homeTeamId e awayTeamId referenciam módulo teams — boundary explicitado em DR-MATCH-002.",
+        "lineupUserIds referenciam módulo users — boundary explicitado em DR-MATCH-001.",
+        "officialIncidentIds referenciam módulo incidents (scheduling futuro) — DEC-MATCHES-001: CRUD simples.",
+        "addPlayerToLineup usa operationId=addPlayerToLineup mas runtime usa PUT; patchMatch usa PATCH — mapeamento documentado em DEC-MATCHES-001."
+      ],
+      "source_fingerprint": "97738af312c6c1b8bc681ad261f8ac87f96ccf81e3fd516f531c9af2ad056b81"
+    },
+    "openapi_contract_view": {
+      "artifact_id": "HBTRACK_SOURCE_GRAPH_OPENAPI_CONTRACT_VIEW",
+      "compiler": "hbtrack_source_graph_compiler",
+      "compiler_version": "0.1.0",
+      "errors": [
+        {
+          "http_status": 401,
+          "id": "ERR-MATCH-401-UNAUTHENTICATED",
+          "kind": "transport",
+          "operations": [
+            "listMatches",
+            "createMatch",
+            "getMatch",
+            "patchMatch",
+            "addPlayerToLineup",
+            "removePlayerFromLineup"
+          ],
+          "source_ref": "../../../../../src/matches/api.py#_role"
+        },
+        {
+          "exception_ref": "../../../../../src/matches/domain/rules.py#InsufficientPrivilege",
+          "http_status": 403,
+          "id": "ERR-MATCH-403-INSUFFICIENT-PRIVILEGE",
+          "kind": "domain",
+          "operations": [
+            "createMatch",
+            "patchMatch",
+            "addPlayerToLineup",
+            "removePlayerFromLineup"
+          ]
+        },
+        {
+          "exception_ref": "../../../../../src/matches/domain/rules.py#MatchNotFound",
+          "http_status": 404,
+          "id": "ERR-MATCH-404-NOT-FOUND",
+          "kind": "domain",
+          "operations": [
+            "getMatch",
+            "patchMatch",
+            "addPlayerToLineup",
+            "removePlayerFromLineup"
+          ]
+        },
+        {
+          "http_status": 400,
+          "id": "ERR-MATCH-400-VALIDATION",
+          "kind": "domain",
+          "operations": [
+            "createMatch",
+            "patchMatch"
+          ],
+          "source_ref": "../../../../../src/matches/domain/entities.py#validate_invariants"
+        },
+        {
+          "exception_ref": "../../../../../src/matches/domain/rules.py#MatchStateError",
+          "http_status": 409,
+          "id": "ERR-MATCH-409-STATE-ERROR",
+          "kind": "domain",
+          "operations": [
+            "createMatch",
+            "patchMatch",
+            "addPlayerToLineup",
+            "removePlayerFromLineup"
+          ]
+        },
+        {
+          "http_status": 500,
+          "id": "ERR-MATCH-500-INTERNAL",
+          "kind": "transport",
+          "operations": [
+            "listMatches",
+            "createMatch",
+            "getMatch",
+            "patchMatch",
+            "addPlayerToLineup",
+            "removePlayerFromLineup"
+          ],
+          "source_ref": "../../../../../src/matches/api.py#list_matches"
+        }
+      ],
+      "module": "matches",
+      "openapi_paths_ref": "contracts/openapi/paths/matches.yaml",
+      "operations": [
+        {
+          "method": "GET",
+          "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/get",
+          "operation_id": "listMatches",
+          "owner_scoped_roles": [],
+          "path": "/matches",
+          "response_codes": [
+            200,
+            401,
+            403,
+            500
+          ],
+          "roles_allowed": [
+            "admin",
+            "coordinator",
+            "coach",
+            "athlete",
+            "member"
+          ],
+          "roles_denied": [],
+          "runtime_handler_ref": "../../../../../src/matches/api.py#list_matches",
+          "use_case_ref": "../../../../../src/matches/application/use_cases.py#ListMatches"
+        },
+        {
+          "method": "POST",
+          "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/post",
+          "operation_id": "createMatch",
+          "owner_scoped_roles": [],
+          "path": "/matches",
+          "response_codes": [
+            201,
+            400,
+            401,
+            403,
+            409,
+            500
+          ],
+          "roles_allowed": [
+            "admin",
+            "coordinator"
+          ],
+          "roles_denied": [
+            "coach",
+            "athlete",
+            "member"
+          ],
+          "runtime_handler_ref": "../../../../../src/matches/api.py#create_match",
+          "use_case_ref": "../../../../../src/matches/application/use_cases.py#CreateMatch"
+        },
+        {
+          "method": "GET",
+          "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/get",
+          "operation_id": "getMatch",
+          "owner_scoped_roles": [],
+          "path": "/matches/{matchId}",
+          "response_codes": [
+            200,
+            401,
+            403,
+            404,
+            500
+          ],
+          "roles_allowed": [
+            "admin",
+            "coordinator",
+            "coach",
+            "athlete",
+            "member"
+          ],
+          "roles_denied": [],
+          "runtime_handler_ref": "../../../../../src/matches/api.py#get_match",
+          "use_case_ref": "../../../../../src/matches/application/use_cases.py#GetMatch"
+        },
+        {
+          "method": "PATCH",
+          "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/patch",
+          "operation_id": "patchMatch",
+          "owner_scoped_roles": [],
+          "path": "/matches/{matchId}",
+          "response_codes": [
+            200,
+            400,
+            401,
+            403,
+            404,
+            409,
+            500
+          ],
+          "roles_allowed": [
+            "admin",
+            "coordinator"
+          ],
+          "roles_denied": [
+            "coach",
+            "athlete",
+            "member"
+          ],
+          "runtime_handler_ref": "../../../../../src/matches/api.py#patch_match",
+          "use_case_ref": "../../../../../src/matches/application/use_cases.py#PatchMatch"
+        },
+        {
+          "method": "PUT",
+          "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/put",
+          "operation_id": "addPlayerToLineup",
+          "owner_scoped_roles": [],
+          "path": "/matches/{matchId}/lineup/{userId}",
+          "response_codes": [
+            200,
+            400,
+            401,
+            403,
+            404,
+            409,
+            500
+          ],
+          "roles_allowed": [
+            "admin",
+            "coordinator",
+            "coach"
+          ],
+          "roles_denied": [
+            "athlete",
+            "member"
+          ],
+          "runtime_handler_ref": "../../../../../src/matches/api.py#add_player_to_lineup",
+          "use_case_ref": "../../../../../src/matches/application/use_cases.py#AddPlayerToLineup"
+        },
+        {
+          "method": "DELETE",
+          "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/delete",
+          "operation_id": "removePlayerFromLineup",
+          "owner_scoped_roles": [],
+          "path": "/matches/{matchId}/lineup/{userId}",
+          "response_codes": [
+            200,
+            400,
+            401,
+            403,
+            404,
+            409,
+            500
+          ],
+          "roles_allowed": [
+            "admin",
+            "coordinator",
+            "coach"
+          ],
+          "roles_denied": [
+            "athlete",
+            "member"
+          ],
+          "runtime_handler_ref": "../../../../../src/matches/api.py#remove_player_from_lineup",
+          "use_case_ref": "../../../../../src/matches/application/use_cases.py#RemovePlayerFromLineup"
+        }
+      ]
+    },
+    "operations": [
+      {
+        "method": "GET",
+        "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/get",
+        "operation_id": "listMatches",
+        "owner_scoped_roles": [],
+        "path": "/matches",
+        "response_codes": [
+          200,
+          401,
+          403,
+          500
+        ],
+        "roles_allowed": [
+          "admin",
+          "coordinator",
+          "coach",
+          "athlete",
+          "member"
+        ],
+        "roles_denied": [],
+        "runtime_handler_ref": "../../../../../src/matches/api.py#list_matches",
+        "use_case_ref": "../../../../../src/matches/application/use_cases.py#ListMatches"
+      },
+      {
+        "method": "POST",
+        "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/post",
+        "operation_id": "createMatch",
+        "owner_scoped_roles": [],
+        "path": "/matches",
+        "response_codes": [
+          201,
+          400,
+          401,
+          403,
+          409,
+          500
+        ],
+        "roles_allowed": [
+          "admin",
+          "coordinator"
+        ],
+        "roles_denied": [
+          "coach",
+          "athlete",
+          "member"
+        ],
+        "runtime_handler_ref": "../../../../../src/matches/api.py#create_match",
+        "use_case_ref": "../../../../../src/matches/application/use_cases.py#CreateMatch"
+      },
+      {
+        "method": "GET",
+        "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/get",
+        "operation_id": "getMatch",
+        "owner_scoped_roles": [],
+        "path": "/matches/{matchId}",
+        "response_codes": [
+          200,
+          401,
+          403,
+          404,
+          500
+        ],
+        "roles_allowed": [
+          "admin",
+          "coordinator",
+          "coach",
+          "athlete",
+          "member"
+        ],
+        "roles_denied": [],
+        "runtime_handler_ref": "../../../../../src/matches/api.py#get_match",
+        "use_case_ref": "../../../../../src/matches/application/use_cases.py#GetMatch"
+      },
+      {
+        "method": "PATCH",
+        "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/patch",
+        "operation_id": "patchMatch",
+        "owner_scoped_roles": [],
+        "path": "/matches/{matchId}",
+        "response_codes": [
+          200,
+          400,
+          401,
+          403,
+          404,
+          409,
+          500
+        ],
+        "roles_allowed": [
+          "admin",
+          "coordinator"
+        ],
+        "roles_denied": [
+          "coach",
+          "athlete",
+          "member"
+        ],
+        "runtime_handler_ref": "../../../../../src/matches/api.py#patch_match",
+        "use_case_ref": "../../../../../src/matches/application/use_cases.py#PatchMatch"
+      },
+      {
+        "method": "PUT",
+        "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/put",
+        "operation_id": "addPlayerToLineup",
+        "owner_scoped_roles": [],
+        "path": "/matches/{matchId}/lineup/{userId}",
+        "response_codes": [
+          200,
+          400,
+          401,
+          403,
+          404,
+          409,
+          500
+        ],
+        "roles_allowed": [
+          "admin",
+          "coordinator",
+          "coach"
+        ],
+        "roles_denied": [
+          "athlete",
+          "member"
+        ],
+        "runtime_handler_ref": "../../../../../src/matches/api.py#add_player_to_lineup",
+        "use_case_ref": "../../../../../src/matches/application/use_cases.py#AddPlayerToLineup"
+      },
+      {
+        "method": "DELETE",
+        "openapi_ref": "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/delete",
+        "operation_id": "removePlayerFromLineup",
+        "owner_scoped_roles": [],
+        "path": "/matches/{matchId}/lineup/{userId}",
+        "response_codes": [
+          200,
+          400,
+          401,
+          403,
+          404,
+          409,
+          500
+        ],
+        "roles_allowed": [
+          "admin",
+          "coordinator",
+          "coach"
+        ],
+        "roles_denied": [
+          "athlete",
+          "member"
+        ],
+        "runtime_handler_ref": "../../../../../src/matches/api.py#remove_player_from_lineup",
+        "use_case_ref": "../../../../../src/matches/application/use_cases.py#RemovePlayerFromLineup"
+      }
+    ],
+    "schema_contract_view": {
+      "artifact_id": "HBTRACK_SOURCE_GRAPH_SCHEMA_CONTRACT_VIEW",
+      "compiler": "hbtrack_source_graph_compiler",
+      "compiler_version": "0.1.0",
+      "entities": {
+        "Match": {
+          "required": [
+            "id",
+            "competitionId",
+            "homeTeamId",
+            "awayTeamId",
+            "statusLabel",
+            "scheduledAt",
+            "lineupUserIds",
+            "officialIncidentIds",
+            "refereeNames",
+            "createdAt",
+            "updatedAt"
+          ],
+          "runtime_extension_fields": [],
+          "schema_ref": "contracts/schemas/matches/match.schema.json",
+          "sovereign_fields": [
+            {
+              "name": "id",
+              "required": true,
+              "runtime_name": "id",
+              "type": "uuid_v4"
+            },
+            {
+              "constraints": [
+                "DR-MATCH-001: matches é soberano do registro oficial; competitionId é obrigatório",
+                "INV-MATCH-001: campo obrigatório",
+                "boundary: reference to competitions module"
+              ],
+              "name": "competitionId",
+              "required": true,
+              "runtime_name": "competition_id",
+              "type": "uuid_v4"
+            },
+            {
+              "constraints": [
+                "DR-MATCH-002: equipe mandante",
+                "INV-MATCH-001: campo obrigatório",
+                "INV-MATCH-002: homeTeamId != awayTeamId",
+                "boundary: reference to teams module"
+              ],
+              "name": "homeTeamId",
+              "required": true,
+              "runtime_name": "home_team_id",
+              "type": "uuid_v4"
+            },
+            {
+              "constraints": [
+                "DR-MATCH-002: equipe visitante",
+                "INV-MATCH-001: campo obrigatório",
+                "INV-MATCH-002: homeTeamId != awayTeamId",
+                "boundary: reference to teams module"
+              ],
+              "name": "awayTeamId",
+              "required": true,
+              "runtime_name": "away_team_id",
+              "type": "uuid_v4"
+            },
+            {
+              "constraints": [
+                "nullable: true",
+                "maxLength: 200"
+              ],
+              "name": "venueLabel",
+              "required": false,
+              "runtime_name": "venue_label",
+              "type": "string"
+            },
+            {
+              "constraints": [
+                "DEC-MATCHES-002: 10 fases do ciclo de vida HBR-013",
+                "default: SCHEDULED na criação"
+              ],
+              "name": "statusLabel",
+              "required": true,
+              "runtime_name": "status_label",
+              "type": "enum",
+              "values": [
+                "SCHEDULED",
+                "PRE_MATCH",
+                "FIRST_HALF",
+                "HALF_TIME",
+                "SECOND_HALF",
+                "OVERTIME_1",
+                "OVERTIME_2",
+                "PENALTIES",
+                "COMPLETED",
+                "CANCELLED"
+              ]
+            },
+            {
+              "constraints": [
+                "INV-MATCH-001: campo obrigatório"
+              ],
+              "name": "scheduledAt",
+              "required": true,
+              "runtime_name": "scheduled_at",
+              "type": "datetime"
+            },
+            {
+              "constraints": [
+                "nullable: true",
+                "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+              ],
+              "name": "startedAt",
+              "required": false,
+              "runtime_name": "started_at",
+              "type": "datetime"
+            },
+            {
+              "constraints": [
+                "nullable: true",
+                "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+              ],
+              "name": "endedAt",
+              "required": false,
+              "runtime_name": "ended_at",
+              "type": "datetime"
+            },
+            {
+              "constraints": [
+                "nullable: true",
+                "minimum: 0",
+                "INV-MATCH-003: homeScore >= 0 quando presente"
+              ],
+              "name": "homeScore",
+              "required": false,
+              "runtime_name": "home_score",
+              "type": "integer"
+            },
+            {
+              "constraints": [
+                "nullable: true",
+                "minimum: 0",
+                "INV-MATCH-003: awayScore >= 0 quando presente"
+              ],
+              "name": "awayScore",
+              "required": false,
+              "runtime_name": "away_score",
+              "type": "integer"
+            },
+            {
+              "constraints": [
+                "uniqueItems: true",
+                "INV-MATCH-005: sem duplicatas",
+                "HBR-008: max 16 por equipe",
+                "boundary: reference to users module"
+              ],
+              "name": "lineupUserIds",
+              "required": true,
+              "runtime_name": "lineup_user_ids",
+              "type": "array_of_uuid"
+            },
+            {
+              "constraints": [
+                "uniqueItems: true",
+                "INV-MATCH-005: sem duplicatas",
+                "DEC-MATCHES-001: CRUD simples; súmula alimentada pelo operador pós-jogo"
+              ],
+              "name": "officialIncidentIds",
+              "required": true,
+              "runtime_name": "official_incident_ids",
+              "type": "array_of_uuid"
+            },
+            {
+              "constraints": [
+                "uniqueItems: true",
+                "INV-MATCH-005: sem duplicatas",
+                "DR-MATCH-003: árbitros são nomes simples, não entidades do domínio"
+              ],
+              "name": "refereeNames",
+              "required": true,
+              "runtime_name": "referee_names",
+              "type": "array_of_string"
+            },
+            {
+              "name": "createdAt",
+              "required": true,
+              "runtime_name": "created_at",
+              "type": "datetime"
+            },
+            {
+              "name": "updatedAt",
+              "required": true,
+              "runtime_name": "updated_at",
+              "type": "datetime"
+            }
+          ]
+        }
+      },
+      "entity": "Match",
+      "module": "matches",
+      "openapi_projection_ref": "contracts/openapi/components/schemas/matches/match.yaml",
+      "primary_entity": "Match",
+      "primary_schema_ref": "contracts/schemas/matches/match.schema.json",
+      "required": [
+        "id",
+        "competitionId",
+        "homeTeamId",
+        "awayTeamId",
+        "statusLabel",
+        "scheduledAt",
+        "lineupUserIds",
+        "officialIncidentIds",
+        "refereeNames",
+        "createdAt",
+        "updatedAt"
+      ],
+      "runtime_extension_fields": [],
+      "sovereign_fields": [
+        {
+          "name": "id",
+          "required": true,
+          "runtime_name": "id",
+          "type": "uuid_v4"
+        },
+        {
+          "constraints": [
+            "DR-MATCH-001: matches é soberano do registro oficial; competitionId é obrigatório",
+            "INV-MATCH-001: campo obrigatório",
+            "boundary: reference to competitions module"
+          ],
+          "name": "competitionId",
+          "required": true,
+          "runtime_name": "competition_id",
+          "type": "uuid_v4"
+        },
+        {
+          "constraints": [
+            "DR-MATCH-002: equipe mandante",
+            "INV-MATCH-001: campo obrigatório",
+            "INV-MATCH-002: homeTeamId != awayTeamId",
+            "boundary: reference to teams module"
+          ],
+          "name": "homeTeamId",
+          "required": true,
+          "runtime_name": "home_team_id",
+          "type": "uuid_v4"
+        },
+        {
+          "constraints": [
+            "DR-MATCH-002: equipe visitante",
+            "INV-MATCH-001: campo obrigatório",
+            "INV-MATCH-002: homeTeamId != awayTeamId",
+            "boundary: reference to teams module"
+          ],
+          "name": "awayTeamId",
+          "required": true,
+          "runtime_name": "away_team_id",
+          "type": "uuid_v4"
+        },
+        {
+          "constraints": [
+            "nullable: true",
+            "maxLength: 200"
+          ],
+          "name": "venueLabel",
+          "required": false,
+          "runtime_name": "venue_label",
+          "type": "string"
+        },
+        {
+          "constraints": [
+            "DEC-MATCHES-002: 10 fases do ciclo de vida HBR-013",
+            "default: SCHEDULED na criação"
+          ],
+          "name": "statusLabel",
+          "required": true,
+          "runtime_name": "status_label",
+          "type": "enum",
+          "values": [
+            "SCHEDULED",
+            "PRE_MATCH",
+            "FIRST_HALF",
+            "HALF_TIME",
+            "SECOND_HALF",
+            "OVERTIME_1",
+            "OVERTIME_2",
+            "PENALTIES",
+            "COMPLETED",
+            "CANCELLED"
+          ]
+        },
+        {
+          "constraints": [
+            "INV-MATCH-001: campo obrigatório"
+          ],
+          "name": "scheduledAt",
+          "required": true,
+          "runtime_name": "scheduled_at",
+          "type": "datetime"
+        },
+        {
+          "constraints": [
+            "nullable: true",
+            "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+          ],
+          "name": "startedAt",
+          "required": false,
+          "runtime_name": "started_at",
+          "type": "datetime"
+        },
+        {
+          "constraints": [
+            "nullable: true",
+            "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+          ],
+          "name": "endedAt",
+          "required": false,
+          "runtime_name": "ended_at",
+          "type": "datetime"
+        },
+        {
+          "constraints": [
+            "nullable: true",
+            "minimum: 0",
+            "INV-MATCH-003: homeScore >= 0 quando presente"
+          ],
+          "name": "homeScore",
+          "required": false,
+          "runtime_name": "home_score",
+          "type": "integer"
+        },
+        {
+          "constraints": [
+            "nullable: true",
+            "minimum: 0",
+            "INV-MATCH-003: awayScore >= 0 quando presente"
+          ],
+          "name": "awayScore",
+          "required": false,
+          "runtime_name": "away_score",
+          "type": "integer"
+        },
+        {
+          "constraints": [
+            "uniqueItems: true",
+            "INV-MATCH-005: sem duplicatas",
+            "HBR-008: max 16 por equipe",
+            "boundary: reference to users module"
+          ],
+          "name": "lineupUserIds",
+          "required": true,
+          "runtime_name": "lineup_user_ids",
+          "type": "array_of_uuid"
+        },
+        {
+          "constraints": [
+            "uniqueItems: true",
+            "INV-MATCH-005: sem duplicatas",
+            "DEC-MATCHES-001: CRUD simples; súmula alimentada pelo operador pós-jogo"
+          ],
+          "name": "officialIncidentIds",
+          "required": true,
+          "runtime_name": "official_incident_ids",
+          "type": "array_of_uuid"
+        },
+        {
+          "constraints": [
+            "uniqueItems: true",
+            "INV-MATCH-005: sem duplicatas",
+            "DR-MATCH-003: árbitros são nomes simples, não entidades do domínio"
+          ],
+          "name": "refereeNames",
+          "required": true,
+          "runtime_name": "referee_names",
+          "type": "array_of_string"
+        },
+        {
+          "name": "createdAt",
+          "required": true,
+          "runtime_name": "created_at",
+          "type": "datetime"
+        },
+        {
+          "name": "updatedAt",
+          "required": true,
+          "runtime_name": "updated_at",
+          "type": "datetime"
+        }
+      ]
+    },
+    "test_obligations": [
+      {
+        "artifact_ref": "../../../../../contracts/schemas/matches/match.schema.json",
+        "evidence_refs": [
+          "../../../../../_reports/contract_gates/latest.json"
+        ],
+        "id": "MATCH-TO-001",
+        "scope": "sovereign_schema",
+        "verification": "JSON Schema validation via contract gates"
+      },
+      {
+        "artifact_ref": "../../../../../contracts/openapi/paths/matches.yaml",
+        "evidence_refs": [
+          "../../../../../_reports/contract_gates/latest.json"
+        ],
+        "id": "MATCH-TO-002",
+        "scope": "openapi_contract",
+        "verification": "OpenAPI lint and contract-gate validation"
+      },
+      {
+        "artifact_ref": "../../../../../src/matches/tests/unit/test_matches_domain.py",
+        "covers": [
+          "INV-MATCH-001",
+          "INV-MATCH-002",
+          "INV-MATCH-003",
+          "INV-MATCH-004",
+          "INV-MATCH-005",
+          "DR-MATCH-001",
+          "DR-MATCH-002",
+          "DR-MATCH-003",
+          "DR-MATCH-004",
+          "DR-MATCH-005"
+        ],
+        "evidence_refs": [
+          "../../../../../src/matches/tests/unit/test_matches_domain.py"
+        ],
+        "id": "MATCH-TO-003",
+        "scope": "domain_invariants_and_permissions",
+        "verification": "Domain unit tests enforcing invariants, boundary rules and permission checks"
+      },
+      {
+        "artifact_ref": "../../../../../tests/pipeline_gates/test_matches_source_graph_integrity.py",
+        "evidence_refs": [
+          "../../../../../tests/pipeline_gates/test_matches_source_graph_integrity.py"
+        ],
+        "id": "MATCH-TO-004",
+        "scope": "source_graph_integrity",
+        "verification": "Pipeline gate enforces parity between graph, docs, contracts and runtime refs"
+      }
+    ]
+  },
+  "validation": {
+    "blocking_consumers": [
+      "docs/hbtrack/modulos/matches/README.md",
+      "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md",
+      "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md",
+      "contracts/openapi/paths/matches.yaml",
+      "contracts/openapi/components/schemas/matches/match.yaml"
+    ],
+    "expected_output": "compiled_context/matches/FT-035.json",
+    "required_commands": [
+      "python3 scripts/compile/compile_source_graph.py --module matches --check --format json",
+      "python3 scripts/compile/compile_context_bundle.py --module matches --check --format json",
+      "python3 scripts/compile/compile_source_graph.py --module matches --check --format json",
+      "python3 scripts/compile/compile_context_bundle.py --module matches --check --format json",
+      "python3 scripts/validate_contracts.py --profile ci",
+      "python3 -m pytest tests/pipeline_gates/test_matches_source_graph_integrity.py tests/pipeline_gates/test_source_graph_compiler_matches.py tests/pipeline_gates/test_context_bundle_matches.py -q"
+    ]
+  }
+}

--- a/compiled_context/seasons/FT-018.json
+++ b/compiled_context/seasons/FT-018.json
@@ -79,7 +79,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -91,7 +91,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/seasons/seasons.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/seasons/domain/rules.py",
     "use_cases": "src/seasons/application/use_cases.py"
   },
-  "source_fingerprint": "cdda232559157b8a95fe4d8b940c03aaa77146aef8c1da61315062e34773e5f9",
+  "source_fingerprint": "be01e894c57aa5db345fd29984b89039d7ff92f68f84ee682eb1c86161a7ccf0",
   "source_graph": {
     "entities": {
       "Season": {

--- a/compiled_context/seasons/FT-019.json
+++ b/compiled_context/seasons/FT-019.json
@@ -79,7 +79,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -91,7 +91,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/seasons/seasons.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/seasons/domain/rules.py",
     "use_cases": "src/seasons/application/use_cases.py"
   },
-  "source_fingerprint": "cdda232559157b8a95fe4d8b940c03aaa77146aef8c1da61315062e34773e5f9",
+  "source_fingerprint": "be01e894c57aa5db345fd29984b89039d7ff92f68f84ee682eb1c86161a7ccf0",
   "source_graph": {
     "entities": {
       "Season": {

--- a/compiled_context/seasons/FT-020.json
+++ b/compiled_context/seasons/FT-020.json
@@ -79,7 +79,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -91,7 +91,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/seasons/seasons.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/seasons/domain/rules.py",
     "use_cases": "src/seasons/application/use_cases.py"
   },
-  "source_fingerprint": "cdda232559157b8a95fe4d8b940c03aaa77146aef8c1da61315062e34773e5f9",
+  "source_fingerprint": "be01e894c57aa5db345fd29984b89039d7ff92f68f84ee682eb1c86161a7ccf0",
   "source_graph": {
     "entities": {
       "Season": {

--- a/compiled_context/seasons/FT-021.json
+++ b/compiled_context/seasons/FT-021.json
@@ -79,7 +79,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -91,7 +91,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/seasons/seasons.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/seasons/domain/rules.py",
     "use_cases": "src/seasons/application/use_cases.py"
   },
-  "source_fingerprint": "cdda232559157b8a95fe4d8b940c03aaa77146aef8c1da61315062e34773e5f9",
+  "source_fingerprint": "be01e894c57aa5db345fd29984b89039d7ff92f68f84ee682eb1c86161a7ccf0",
   "source_graph": {
     "entities": {
       "Season": {

--- a/compiled_context/seasons/FT-022.json
+++ b/compiled_context/seasons/FT-022.json
@@ -79,7 +79,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -91,7 +91,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/seasons/seasons.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/seasons/domain/rules.py",
     "use_cases": "src/seasons/application/use_cases.py"
   },
-  "source_fingerprint": "cdda232559157b8a95fe4d8b940c03aaa77146aef8c1da61315062e34773e5f9",
+  "source_fingerprint": "be01e894c57aa5db345fd29984b89039d7ff92f68f84ee682eb1c86161a7ccf0",
   "source_graph": {
     "entities": {
       "Season": {

--- a/compiled_context/seasons/FT-023.json
+++ b/compiled_context/seasons/FT-023.json
@@ -79,7 +79,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -91,7 +91,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/seasons/seasons.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/seasons/domain/rules.py",
     "use_cases": "src/seasons/application/use_cases.py"
   },
-  "source_fingerprint": "cdda232559157b8a95fe4d8b940c03aaa77146aef8c1da61315062e34773e5f9",
+  "source_fingerprint": "be01e894c57aa5db345fd29984b89039d7ff92f68f84ee682eb1c86161a7ccf0",
   "source_graph": {
     "entities": {
       "Season": {

--- a/compiled_context/teams/FT-024.json
+++ b/compiled_context/teams/FT-024.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/teams/FT-025.json
+++ b/compiled_context/teams/FT-025.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/teams/FT-026.json
+++ b/compiled_context/teams/FT-026.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/teams/FT-027.json
+++ b/compiled_context/teams/FT-027.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/teams/FT-028.json
+++ b/compiled_context/teams/FT-028.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/teams/FT-029.json
+++ b/compiled_context/teams/FT-029.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/teams/FT-030.json
+++ b/compiled_context/teams/FT-030.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/teams/FT-031.json
+++ b/compiled_context/teams/FT-031.json
@@ -81,7 +81,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/teams/teams.bundle.yaml",
@@ -139,7 +139,7 @@
     "domain_rules": "src/teams/domain/rules.py",
     "use_cases": "src/teams/application/use_cases.py"
   },
-  "source_fingerprint": "13bc342481688740aeb49b8cf0da73fe0f1ec6f828f9374a404aefb717371682",
+  "source_fingerprint": "61818a9ac5a9430d7be227774e58e5c083ef370be50f6d71f35c0f695de05f1d",
   "source_graph": {
     "entities": {
       "Team": {

--- a/compiled_context/users/FT-014.json
+++ b/compiled_context/users/FT-014.json
@@ -77,7 +77,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -89,7 +89,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/users/users.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/users/domain/rules.py",
     "use_cases": "src/users/application/use_cases.py"
   },
-  "source_fingerprint": "5b107d147e7d6c6621c77a8407c4420a2297ce9b4ed2d6b8752448da889f3ee6",
+  "source_fingerprint": "dce61d8de80bbd41e9f23e0c5f761e58545c1c7fac15d91b2474541a0a2baccd",
   "source_graph": {
     "entities": {
       "UserProfile": {

--- a/compiled_context/users/FT-015.json
+++ b/compiled_context/users/FT-015.json
@@ -77,7 +77,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -89,7 +89,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/users/users.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/users/domain/rules.py",
     "use_cases": "src/users/application/use_cases.py"
   },
-  "source_fingerprint": "5b107d147e7d6c6621c77a8407c4420a2297ce9b4ed2d6b8752448da889f3ee6",
+  "source_fingerprint": "dce61d8de80bbd41e9f23e0c5f761e58545c1c7fac15d91b2474541a0a2baccd",
   "source_graph": {
     "entities": {
       "UserProfile": {

--- a/compiled_context/users/FT-016.json
+++ b/compiled_context/users/FT-016.json
@@ -77,7 +77,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -89,7 +89,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/users/users.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/users/domain/rules.py",
     "use_cases": "src/users/application/use_cases.py"
   },
-  "source_fingerprint": "5b107d147e7d6c6621c77a8407c4420a2297ce9b4ed2d6b8752448da889f3ee6",
+  "source_fingerprint": "dce61d8de80bbd41e9f23e0c5f761e58545c1c7fac15d91b2474541a0a2baccd",
   "source_graph": {
     "entities": {
       "UserProfile": {

--- a/compiled_context/users/FT-017.json
+++ b/compiled_context/users/FT-017.json
@@ -77,7 +77,7 @@
   "inputs": [
     {
       "relpath": "docs/_canon/FEATURE_REGISTRY.yaml",
-      "sha256": "15e0e2a667ccc54f93ab4d2dbc84c2ffd1b7bf5268771396a3b85d0572cd58c0"
+      "sha256": "b5f91816da37dd81551c63ddb32bf7d528db4ea606a7fe28c99f64b9b69512b8"
     },
     {
       "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
@@ -89,7 +89,7 @@
     },
     {
       "relpath": "docs/_canon/SYNC_MANIFEST.yaml",
-      "sha256": "19492a7e089ac97bb5c81ee9249914560d25edd2b7125b1497d7d8c8f612cfee"
+      "sha256": "c5446e63ede4771183942aed2fa78b8b009653272456511d402ada2083a78d9c"
     },
     {
       "relpath": "generated/source_graph/users/users.bundle.yaml",
@@ -137,7 +137,7 @@
     "domain_rules": "src/users/domain/rules.py",
     "use_cases": "src/users/application/use_cases.py"
   },
-  "source_fingerprint": "5b107d147e7d6c6621c77a8407c4420a2297ce9b4ed2d6b8752448da889f3ee6",
+  "source_fingerprint": "dce61d8de80bbd41e9f23e0c5f761e58545c1c7fac15d91b2474541a0a2baccd",
   "source_graph": {
     "entities": {
       "UserProfile": {

--- a/docs/_canon/DOC_USAGE_MANIFEST.yaml
+++ b/docs/_canon/DOC_USAGE_MANIFEST.yaml
@@ -450,6 +450,25 @@ entries:
       - "src/users/"
       - "tests/pipeline_gates/test_users_source_graph_integrity.py"
 
+  - rule_id: HBTRACK_MATCHES_GRAPH
+    class: hbtrack_module_graph
+    path_globs:
+      - "docs/hbtrack/modulos/matches/graph/*.yaml"
+    owner_source: "docs/hbtrack/modulos/matches/graph/module_manifest.yaml"
+    consumers:
+      - "docs/hbtrack/modulos/matches/README.md"
+      - "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md"
+      - "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md"
+      - "tests/pipeline_gates/test_matches_source_graph_integrity.py"
+    freshness_mode: domain_governed
+    update_triggers:
+      - "docs/hbtrack/modulos/matches/*.md"
+      - "contracts/schemas/matches/"
+      - "contracts/openapi/paths/matches.yaml"
+      - "contracts/openapi/components/schemas/matches/"
+      - "src/matches/"
+      - "tests/pipeline_gates/test_matches_source_graph_integrity.py"
+
   - rule_id: CANON_ADR_INDEX
     class: canon_decision_index
     paths:

--- a/docs/_canon/FEATURE_REGISTRY.yaml
+++ b/docs/_canon/FEATURE_REGISTRY.yaml
@@ -542,7 +542,9 @@ features:
       - GET /matches
       - POST /matches
       - GET /matches/{matchId}
-      - POST /matches/{matchId}/lineup/{userId}
+      - PATCH /matches/{matchId}
+      - PUT /matches/{matchId}/lineup/{userId}
+      - DELETE /matches/{matchId}/lineup/{userId}
     status: implemented
     contracts:
       - contracts/openapi/paths/matches.yaml

--- a/docs/_canon/SYNC_MANIFEST.yaml
+++ b/docs/_canon/SYNC_MANIFEST.yaml
@@ -1066,3 +1066,50 @@ rules:
       - "python3 scripts/compile/compile_context_bundle.py --module users --check --format json"
       - "python3 scripts/validate_contracts.py --profile ci"
       - "python3 -m pytest tests/pipeline_gates/test_users_source_graph_integrity.py tests/pipeline_gates/test_source_graph_compiler_users.py tests/pipeline_gates/test_context_bundle_users.py -q"
+
+  - rule_id: MATCHES_SOURCE_GRAPH_SYNC
+    source_master: "docs/hbtrack/modulos/matches/graph/module_manifest.yaml"
+    source_inputs:
+      - "docs/hbtrack/modulos/matches/graph/entities.yaml"
+      - "docs/hbtrack/modulos/matches/graph/endpoints.yaml"
+      - "docs/hbtrack/modulos/matches/graph/errors.yaml"
+      - "docs/hbtrack/modulos/matches/graph/test_obligations.yaml"
+    source_kind: module_source_graph
+    change_types:
+      - domain_contract_change
+      - runtime_projection_change
+      - codegen_shape_change
+    required_consumers:
+      - "docs/hbtrack/modulos/matches/README.md"
+      - "docs/hbtrack/modulos/matches/MODULE_SCOPE_MATCHES.md"
+      - "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md"
+      - "docs/hbtrack/modulos/matches/INVARIANTS_MATCHES.md"
+      - "docs/hbtrack/modulos/matches/PERMISSIONS_MATCHES.md"
+      - "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md"
+      - "contracts/openapi/paths/matches.yaml"
+      - "contracts/openapi/components/schemas/matches/match.yaml"
+      - "contracts/schemas/matches/match.schema.json"
+      - "generated/source_graph/matches/matches.bundle.yaml"
+      - "generated/source_graph/matches/matches.schema_contract_view.yaml"
+      - "generated/source_graph/matches/matches.openapi_contract_view.yaml"
+      - "generated/source_graph/matches/impact_report.json"
+      - "compiled_context/matches/FT-035.json"
+      - "src/matches/api.py"
+      - "src/matches/schemas.py"
+      - "src/matches/domain/entities.py"
+      - "src/matches/domain/rules.py"
+      - "src/matches/application/use_cases.py"
+      - "tests/pipeline_gates/test_matches_source_graph_integrity.py"
+      - "tests/pipeline_gates/test_source_graph_compiler_matches.py"
+      - "tests/pipeline_gates/test_context_bundle_matches.py"
+    blocking_consumers:
+      - "docs/hbtrack/modulos/matches/README.md"
+      - "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md"
+      - "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md"
+      - "contracts/openapi/paths/matches.yaml"
+      - "contracts/openapi/components/schemas/matches/match.yaml"
+    validation_commands:
+      - "python3 scripts/compile/compile_source_graph.py --module matches --check --format json"
+      - "python3 scripts/compile/compile_context_bundle.py --module matches --check --format json"
+      - "python3 scripts/validate_contracts.py --profile ci"
+      - "python3 -m pytest tests/pipeline_gates/test_matches_source_graph_integrity.py tests/pipeline_gates/test_source_graph_compiler_matches.py tests/pipeline_gates/test_context_bundle_matches.py -q"

--- a/docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md
+++ b/docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md
@@ -33,3 +33,9 @@ Registrar as regras de negócio do módulo `matches`.
 - Não inferir taxonomia tática completa sem glossário próprio de `scout`.
 - Não mover credenciais, regra médica ou autorização para `matches`.
 - Não usar benchmark externo como norma oficial sem mapeamento explícito.
+
+## Source Graph
+- Entidades: [graph/entities.yaml](graph/entities.yaml)
+- Endpoints: [graph/endpoints.yaml](graph/endpoints.yaml)
+- Erros: [graph/errors.yaml](graph/errors.yaml)
+- Obrigações: [graph/test_obligations.yaml](graph/test_obligations.yaml)

--- a/docs/hbtrack/modulos/matches/README.md
+++ b/docs/hbtrack/modulos/matches/README.md
@@ -27,3 +27,10 @@ Documentar o escopo normativo do módulo `matches` e suas superfícies soberanas
 - `docs/_canon/SYSTEM_SCOPE.md`
 - `docs/_canon/HANDBALL_RULES_DOMAIN.md` (quando o gatilho de handebol aplicar)
 - SSOT de convenções/templates de API HTTP: `.contract_driven/templates/api/api_rules.yaml`
+
+## Source Graph
+- [graph/module_manifest.yaml](graph/module_manifest.yaml)
+- [graph/entities.yaml](graph/entities.yaml)
+- [graph/endpoints.yaml](graph/endpoints.yaml)
+- [graph/errors.yaml](graph/errors.yaml)
+- [graph/test_obligations.yaml](graph/test_obligations.yaml)

--- a/docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md
+++ b/docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md
@@ -19,3 +19,7 @@ Definir a matriz mínima de testes e evidências que sustentam os contratos do m
 | TM-002 | `contracts/schemas/matches/` | Validação JSON Schema | Sim | `_reports/contract_gates/latest.json` |
 | TM-003 | `DOMAIN_RULES_MATCHES.md` | Revisão normativa + testes de regra (quando existir) | Condicional | `_reports/contract_gates/latest.json` |
 | TM-004 | `INVARIANTS_MATCHES.md` | Teste de invariantes (quando existir) | Condicional | `_reports/contract_gates/latest.json` |
+| TM-005 | `graph/test_obligations.yaml` | Source graph — obrigações de teste MATCH-TO-001..004 | Sim | `tests/pipeline_gates/test_matches_source_graph_integrity.py` |
+
+## Obrigações
+- Obrigações: [graph/test_obligations.yaml](graph/test_obligations.yaml)

--- a/docs/hbtrack/modulos/matches/graph/endpoints.yaml
+++ b/docs/hbtrack/modulos/matches/graph/endpoints.yaml
@@ -1,0 +1,136 @@
+version: "1.0.0"
+status: active
+module: matches
+
+endpoints:
+  - operation_id: listMatches
+    method: GET
+    path: /matches
+    openapi_ref: "../../../../../contracts/openapi/paths/matches.yaml#/matches/get"
+    runtime_handler_ref: "../../../../../src/matches/api.py#list_matches"
+    use_case_ref: "../../../../../src/matches/application/use_cases.py#ListMatches"
+    roles_allowed:
+      - admin
+      - coordinator
+      - coach
+      - athlete
+      - member
+    roles_denied: []
+    owner_scoped_roles: []
+    response_codes:
+      - 200
+      - 401
+      - 403
+      - 500
+
+  - operation_id: createMatch
+    method: POST
+    path: /matches
+    openapi_ref: "../../../../../contracts/openapi/paths/matches.yaml#/matches/post"
+    runtime_handler_ref: "../../../../../src/matches/api.py#create_match"
+    use_case_ref: "../../../../../src/matches/application/use_cases.py#CreateMatch"
+    roles_allowed:
+      - admin
+      - coordinator
+    roles_denied:
+      - coach
+      - athlete
+      - member
+    owner_scoped_roles: []
+    response_codes:
+      - 201
+      - 400
+      - 401
+      - 403
+      - 409
+      - 500
+
+  - operation_id: getMatch
+    method: GET
+    path: /matches/{matchId}
+    openapi_ref: "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/get"
+    runtime_handler_ref: "../../../../../src/matches/api.py#get_match"
+    use_case_ref: "../../../../../src/matches/application/use_cases.py#GetMatch"
+    roles_allowed:
+      - admin
+      - coordinator
+      - coach
+      - athlete
+      - member
+    roles_denied: []
+    owner_scoped_roles: []
+    response_codes:
+      - 200
+      - 401
+      - 403
+      - 404
+      - 500
+
+  - operation_id: patchMatch
+    method: PATCH
+    path: /matches/{matchId}
+    openapi_ref: "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/patch"
+    runtime_handler_ref: "../../../../../src/matches/api.py#patch_match"
+    use_case_ref: "../../../../../src/matches/application/use_cases.py#PatchMatch"
+    roles_allowed:
+      - admin
+      - coordinator
+    roles_denied:
+      - coach
+      - athlete
+      - member
+    owner_scoped_roles: []
+    response_codes:
+      - 200
+      - 400
+      - 401
+      - 403
+      - 404
+      - 409
+      - 500
+
+  - operation_id: addPlayerToLineup
+    method: PUT
+    path: /matches/{matchId}/lineup/{userId}
+    openapi_ref: "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/put"
+    runtime_handler_ref: "../../../../../src/matches/api.py#add_player_to_lineup"
+    use_case_ref: "../../../../../src/matches/application/use_cases.py#AddPlayerToLineup"
+    roles_allowed:
+      - admin
+      - coordinator
+      - coach
+    roles_denied:
+      - athlete
+      - member
+    owner_scoped_roles: []
+    response_codes:
+      - 200
+      - 400
+      - 401
+      - 403
+      - 404
+      - 409
+      - 500
+
+  - operation_id: removePlayerFromLineup
+    method: DELETE
+    path: /matches/{matchId}/lineup/{userId}
+    openapi_ref: "../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/delete"
+    runtime_handler_ref: "../../../../../src/matches/api.py#remove_player_from_lineup"
+    use_case_ref: "../../../../../src/matches/application/use_cases.py#RemovePlayerFromLineup"
+    roles_allowed:
+      - admin
+      - coordinator
+      - coach
+    roles_denied:
+      - athlete
+      - member
+    owner_scoped_roles: []
+    response_codes:
+      - 200
+      - 400
+      - 401
+      - 403
+      - 404
+      - 409
+      - 500

--- a/docs/hbtrack/modulos/matches/graph/entities.yaml
+++ b/docs/hbtrack/modulos/matches/graph/entities.yaml
@@ -1,0 +1,157 @@
+version: "1.0.0"
+status: active
+module: matches
+
+entities:
+  Match:
+    schema_ref: "../../../../../contracts/schemas/matches/match.schema.json"
+    runtime_entity_ref: "../../../../../src/matches/domain/entities.py#Match"
+    docs_refs:
+      - "../DOMAIN_RULES_MATCHES.md"
+      - "../INVARIANTS_MATCHES.md"
+      - "../PERMISSIONS_MATCHES.md"
+    sovereign_fields:
+      - name: id
+        runtime_name: id
+        required: true
+        type: uuid_v4
+      - name: competitionId
+        runtime_name: competition_id
+        required: true
+        type: uuid_v4
+        constraints:
+          - "DR-MATCH-001: matches é soberano do registro oficial; competitionId é obrigatório"
+          - "INV-MATCH-001: campo obrigatório"
+          - "boundary: reference to competitions module"
+      - name: homeTeamId
+        runtime_name: home_team_id
+        required: true
+        type: uuid_v4
+        constraints:
+          - "DR-MATCH-002: equipe mandante"
+          - "INV-MATCH-001: campo obrigatório"
+          - "INV-MATCH-002: homeTeamId != awayTeamId"
+          - "boundary: reference to teams module"
+      - name: awayTeamId
+        runtime_name: away_team_id
+        required: true
+        type: uuid_v4
+        constraints:
+          - "DR-MATCH-002: equipe visitante"
+          - "INV-MATCH-001: campo obrigatório"
+          - "INV-MATCH-002: homeTeamId != awayTeamId"
+          - "boundary: reference to teams module"
+      - name: venueLabel
+        runtime_name: venue_label
+        required: false
+        type: string
+        constraints:
+          - "nullable: true"
+          - "maxLength: 200"
+      - name: statusLabel
+        runtime_name: status_label
+        required: true
+        type: enum
+        values:
+          - SCHEDULED
+          - PRE_MATCH
+          - FIRST_HALF
+          - HALF_TIME
+          - SECOND_HALF
+          - OVERTIME_1
+          - OVERTIME_2
+          - PENALTIES
+          - COMPLETED
+          - CANCELLED
+        constraints:
+          - "DEC-MATCHES-002: 10 fases do ciclo de vida HBR-013"
+          - "default: SCHEDULED na criação"
+      - name: scheduledAt
+        runtime_name: scheduled_at
+        required: true
+        type: datetime
+        constraints:
+          - "INV-MATCH-001: campo obrigatório"
+      - name: startedAt
+        runtime_name: started_at
+        required: false
+        type: datetime
+        constraints:
+          - "nullable: true"
+          - "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+      - name: endedAt
+        runtime_name: ended_at
+        required: false
+        type: datetime
+        constraints:
+          - "nullable: true"
+          - "INV-MATCH-004: startedAt <= endedAt quando ambos presentes"
+      - name: homeScore
+        runtime_name: home_score
+        required: false
+        type: integer
+        constraints:
+          - "nullable: true"
+          - "minimum: 0"
+          - "INV-MATCH-003: homeScore >= 0 quando presente"
+      - name: awayScore
+        runtime_name: away_score
+        required: false
+        type: integer
+        constraints:
+          - "nullable: true"
+          - "minimum: 0"
+          - "INV-MATCH-003: awayScore >= 0 quando presente"
+      - name: lineupUserIds
+        runtime_name: lineup_user_ids
+        required: true
+        type: array_of_uuid
+        constraints:
+          - "uniqueItems: true"
+          - "INV-MATCH-005: sem duplicatas"
+          - "HBR-008: max 16 por equipe"
+          - "boundary: reference to users module"
+      - name: officialIncidentIds
+        runtime_name: official_incident_ids
+        required: true
+        type: array_of_uuid
+        constraints:
+          - "uniqueItems: true"
+          - "INV-MATCH-005: sem duplicatas"
+          - "DEC-MATCHES-001: CRUD simples; súmula alimentada pelo operador pós-jogo"
+      - name: refereeNames
+        runtime_name: referee_names
+        required: true
+        type: array_of_string
+        constraints:
+          - "uniqueItems: true"
+          - "INV-MATCH-005: sem duplicatas"
+          - "DR-MATCH-003: árbitros são nomes simples, não entidades do domínio"
+      - name: createdAt
+        runtime_name: created_at
+        required: true
+        type: datetime
+      - name: updatedAt
+        runtime_name: updated_at
+        required: true
+        type: datetime
+
+    domain_enums:
+      - name: RoleLabel
+        values: [admin, coordinator, coach, athlete, member]
+        source: "ADR-008 / SYSTEM_SCOPE.md"
+      - name: MatchStatus
+        values: [SCHEDULED, PRE_MATCH, FIRST_HALF, HALF_TIME, SECOND_HALF, OVERTIME_1, OVERTIME_2, PENALTIES, COMPLETED, CANCELLED]
+        source: "DEC-MATCHES-002 / HBR-013"
+
+    invariants:
+      - id: INV-MATCH-001
+        rule: "id, competition_id, home_team_id, away_team_id, scheduled_at são obrigatórios."
+      - id: INV-MATCH-002
+        rule: "home_team_id deve ser diferente de away_team_id."
+      - id: INV-MATCH-003
+        rule: "home_score e away_score devem ser >= 0 quando presentes."
+      - id: INV-MATCH-004
+        rule: "started_at deve ser <= ended_at quando ambos presentes."
+      - id: INV-MATCH-005
+        rule: "lineup_user_ids, official_incident_ids e referee_names não podem ter duplicatas."

--- a/docs/hbtrack/modulos/matches/graph/errors.yaml
+++ b/docs/hbtrack/modulos/matches/graph/errors.yaml
@@ -1,0 +1,66 @@
+version: "1.0.0"
+status: active
+module: matches
+
+errors:
+  - id: ERR-MATCH-401-UNAUTHENTICATED
+    kind: transport
+    http_status: 401
+    source_ref: "../../../../../src/matches/api.py#_role"
+    operations:
+      - listMatches
+      - createMatch
+      - getMatch
+      - patchMatch
+      - addPlayerToLineup
+      - removePlayerFromLineup
+
+  - id: ERR-MATCH-403-INSUFFICIENT-PRIVILEGE
+    kind: domain
+    http_status: 403
+    exception_ref: "../../../../../src/matches/domain/rules.py#InsufficientPrivilege"
+    operations:
+      - createMatch
+      - patchMatch
+      - addPlayerToLineup
+      - removePlayerFromLineup
+
+  - id: ERR-MATCH-404-NOT-FOUND
+    kind: domain
+    http_status: 404
+    exception_ref: "../../../../../src/matches/domain/rules.py#MatchNotFound"
+    operations:
+      - getMatch
+      - patchMatch
+      - addPlayerToLineup
+      - removePlayerFromLineup
+
+  - id: ERR-MATCH-400-VALIDATION
+    kind: domain
+    http_status: 400
+    source_ref: "../../../../../src/matches/domain/entities.py#validate_invariants"
+    operations:
+      - createMatch
+      - patchMatch
+
+  - id: ERR-MATCH-409-STATE-ERROR
+    kind: domain
+    http_status: 409
+    exception_ref: "../../../../../src/matches/domain/rules.py#MatchStateError"
+    operations:
+      - createMatch
+      - patchMatch
+      - addPlayerToLineup
+      - removePlayerFromLineup
+
+  - id: ERR-MATCH-500-INTERNAL
+    kind: transport
+    http_status: 500
+    source_ref: "../../../../../src/matches/api.py#list_matches"
+    operations:
+      - listMatches
+      - createMatch
+      - getMatch
+      - patchMatch
+      - addPlayerToLineup
+      - removePlayerFromLineup

--- a/docs/hbtrack/modulos/matches/graph/module_manifest.yaml
+++ b/docs/hbtrack/modulos/matches/graph/module_manifest.yaml
@@ -1,0 +1,46 @@
+version: "1.0.0"
+status: active
+module: matches
+phase: source_graph_rollout
+
+global_refs:
+  source_authority_graph: "../../../../_canon/SOURCE_AUTHORITY_GRAPH.yaml"
+  global_rules: "../../../../_canon/graph/global_rules.yaml"
+  global_policies: "../../../../_canon/graph/global_policies.yaml"
+  lifecycle: "../../../../_canon/graph/lifecycle.yaml"
+  module_registry: "../../../../_canon/MODULE_REGISTRY.yaml"
+  module_source_authority_matrix: "../../../../_canon/MODULE_SOURCE_AUTHORITY_MATRIX.yaml"
+
+module_docs:
+  readme: "../README.md"
+  scope: "../MODULE_SCOPE_MATCHES.md"
+  domain_rules: "../DOMAIN_RULES_MATCHES.md"
+  invariants: "../INVARIANTS_MATCHES.md"
+  permissions: "../PERMISSIONS_MATCHES.md"
+  test_matrix: "../TEST_MATRIX_MATCHES.md"
+
+contract_surfaces:
+  openapi_paths: "../../../../../contracts/openapi/paths/matches.yaml"
+  sovereign_schema_dir: "../../../../../contracts/schemas/matches/"
+  primary_schema: "../../../../../contracts/schemas/matches/match.schema.json"
+  openapi_projection: "../../../../../contracts/openapi/components/schemas/matches/match.yaml"
+
+runtime_surfaces:
+  api_router: "../../../../../src/matches/api.py"
+  domain_entity: "../../../../../src/matches/domain/entities.py"
+  domain_rules: "../../../../../src/matches/domain/rules.py"
+  use_cases: "../../../../../src/matches/application/use_cases.py"
+
+structured_ir:
+  entities: "./entities.yaml"
+  endpoints: "./endpoints.yaml"
+  errors: "./errors.yaml"
+  test_obligations: "./test_obligations.yaml"
+
+known_gaps:
+  - "AsyncAPI/Arazzo do módulo seguem governança separada e não estão incluídos nesta fase do source graph."
+  - "competitionId é referência cruzada para módulo competitions — boundary explicitado em DR-MATCH-001."
+  - "homeTeamId e awayTeamId referenciam módulo teams — boundary explicitado em DR-MATCH-002."
+  - "lineupUserIds referenciam módulo users — boundary explicitado em DR-MATCH-001."
+  - "officialIncidentIds referenciam módulo incidents (scheduling futuro) — DEC-MATCHES-001: CRUD simples."
+  - "addPlayerToLineup usa operationId=addPlayerToLineup mas runtime usa PUT; patchMatch usa PATCH — mapeamento documentado em DEC-MATCHES-001."

--- a/docs/hbtrack/modulos/matches/graph/test_obligations.yaml
+++ b/docs/hbtrack/modulos/matches/graph/test_obligations.yaml
@@ -1,0 +1,43 @@
+version: "1.0.0"
+status: active
+module: matches
+
+obligations:
+  - id: MATCH-TO-001
+    scope: sovereign_schema
+    artifact_ref: "../../../../../contracts/schemas/matches/match.schema.json"
+    verification: "JSON Schema validation via contract gates"
+    evidence_refs:
+      - "../../../../../_reports/contract_gates/latest.json"
+
+  - id: MATCH-TO-002
+    scope: openapi_contract
+    artifact_ref: "../../../../../contracts/openapi/paths/matches.yaml"
+    verification: "OpenAPI lint and contract-gate validation"
+    evidence_refs:
+      - "../../../../../_reports/contract_gates/latest.json"
+
+  - id: MATCH-TO-003
+    scope: domain_invariants_and_permissions
+    artifact_ref: "../../../../../src/matches/tests/unit/test_matches_domain.py"
+    covers:
+      - INV-MATCH-001
+      - INV-MATCH-002
+      - INV-MATCH-003
+      - INV-MATCH-004
+      - INV-MATCH-005
+      - DR-MATCH-001
+      - DR-MATCH-002
+      - DR-MATCH-003
+      - DR-MATCH-004
+      - DR-MATCH-005
+    verification: "Domain unit tests enforcing invariants, boundary rules and permission checks"
+    evidence_refs:
+      - "../../../../../src/matches/tests/unit/test_matches_domain.py"
+
+  - id: MATCH-TO-004
+    scope: source_graph_integrity
+    artifact_ref: "../../../../../tests/pipeline_gates/test_matches_source_graph_integrity.py"
+    verification: "Pipeline gate enforces parity between graph, docs, contracts and runtime refs"
+    evidence_refs:
+      - "../../../../../tests/pipeline_gates/test_matches_source_graph_integrity.py"

--- a/generated/source_graph/matches/impact_report.json
+++ b/generated/source_graph/matches/impact_report.json
@@ -1,0 +1,147 @@
+{
+  "artifact_id": "HBTRACK_SOURCE_GRAPH_IMPACT_REPORT",
+  "blocked_partial_update": true,
+  "compiler": "hbtrack_source_graph_compiler",
+  "compiler_version": "0.1.0",
+  "impacted_contracts": [
+    "contracts/openapi/paths/matches.yaml",
+    "contracts/schemas/matches/match.schema.json",
+    "contracts/openapi/components/schemas/matches/match.yaml"
+  ],
+  "impacted_docs": [
+    "docs/hbtrack/modulos/matches/README.md",
+    "docs/hbtrack/modulos/matches/MODULE_SCOPE_MATCHES.md",
+    "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md",
+    "docs/hbtrack/modulos/matches/INVARIANTS_MATCHES.md",
+    "docs/hbtrack/modulos/matches/PERMISSIONS_MATCHES.md",
+    "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md"
+  ],
+  "impacted_runtime": [
+    "src/matches/api.py",
+    "src/matches/domain/entities.py",
+    "src/matches/domain/rules.py",
+    "src/matches/application/use_cases.py"
+  ],
+  "inputs": [
+    {
+      "relpath": "contracts/openapi/components/schemas/matches/match.yaml",
+      "sha256": "f0d38d2f18f7d941921992617b0a46ea169eed2bb2e54d7b8f910350c5fdffbf"
+    },
+    {
+      "relpath": "contracts/openapi/paths/matches.yaml",
+      "sha256": "e21f3446a04b6024d370ba0bc0c0e43eaf275ff07159051dfb0421970f76f705"
+    },
+    {
+      "relpath": "contracts/schemas/matches/.gitkeep",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "relpath": "contracts/schemas/matches/match.schema.json",
+      "sha256": "0794ae1db7742b9d9ddd297496342dc1caa0b8706143099b0dbf2d1b5b974c40"
+    },
+    {
+      "relpath": "docs/_canon/MODULE_REGISTRY.yaml",
+      "sha256": "0f22b477ffaf2dec13c77adc469fd21cbbbf2fd2d6d1d5d6fcf672039972fedd"
+    },
+    {
+      "relpath": "docs/_canon/MODULE_SOURCE_AUTHORITY_MATRIX.yaml",
+      "sha256": "e01c6a21bafe91b849317c2749ffcea1ef1350a5afc2ed95caa5f1d5093a2680"
+    },
+    {
+      "relpath": "docs/_canon/SOURCE_AUTHORITY_GRAPH.yaml",
+      "sha256": "c7ff89bb7bc4e0e1851a3e6b1fd0aeaefbb0a0d5cdfb6a71aad0becfe042d8d1"
+    },
+    {
+      "relpath": "docs/_canon/graph/global_policies.yaml",
+      "sha256": "4715e7504a06b32eecd83cf7e6a69f0ee762a28f3236614099fbff8138169fa2"
+    },
+    {
+      "relpath": "docs/_canon/graph/global_rules.yaml",
+      "sha256": "02f75652679e4e5c981f177b6bc57f77e26b1a360e4452a2828bda448f349f07"
+    },
+    {
+      "relpath": "docs/_canon/graph/lifecycle.yaml",
+      "sha256": "654844a0e8a2eb1f265f1c1dd5a20335a439facf300c56c137eb12c19e41a3c5"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md",
+      "sha256": "8f9679187b7b063fe6a7fed7e449c94fc7d09de6edaf63d58e3bfa84af901a5e"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/INVARIANTS_MATCHES.md",
+      "sha256": "a392e05897096374b733f1c077cf9abced0318cec229ee360cdc73dd4a3e6a94"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/MODULE_SCOPE_MATCHES.md",
+      "sha256": "d605c4a85bc62549eb35341562762a5f448e0a8ecdf70deb16560fc6e5296a23"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/PERMISSIONS_MATCHES.md",
+      "sha256": "836840067b8a17e124574c1ef80cda53d00751a95a9c3e4fb3661e9e05eb89bf"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/README.md",
+      "sha256": "dc0e603582dfbb4d140a8322685624239e03554dbb6cc494dfb3c4f92ad0353a"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md",
+      "sha256": "e664b2877b1e330c6644b7794b3ccd898297cfeedebf9a33ddd5b339b6e9515a"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/graph/endpoints.yaml",
+      "sha256": "7d8b71cd02e7e1388d0bb96ba551fb906f72c0a7bfac8916f58c0b06746db057"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/graph/entities.yaml",
+      "sha256": "dd21d79d79d917a5891deec838c5c0298900378f6d17b4eb7817b853e3c5938a"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/graph/errors.yaml",
+      "sha256": "1039e6a4ced36d117ea24d8a835cc1c7ea22dd5a16e6f9ef6343c881e259b6e8"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/graph/module_manifest.yaml",
+      "sha256": "3113bfb6ed3892fbede26961361bacf37606f511a0848366cecdd9b13613f7da"
+    },
+    {
+      "relpath": "docs/hbtrack/modulos/matches/graph/test_obligations.yaml",
+      "sha256": "c54aef8e24afe03b9a0a62e01f8d531110a35d24d7305bfa31ade47cd811843f"
+    },
+    {
+      "relpath": "src/matches/api.py",
+      "sha256": "da633cac6886fd69804bf2813593de53becff2bf2bfcdb2d3713921d86207ccf"
+    },
+    {
+      "relpath": "src/matches/application/use_cases.py",
+      "sha256": "b6173bb05caacfb5df41d4ac4fa0304b5921baf022997f4bf0d9a3b6716a5b24"
+    },
+    {
+      "relpath": "src/matches/domain/entities.py",
+      "sha256": "4535c2eb63e55e9ec381f523c606070543c60c65cff856ca1fe0773056b1a6b0"
+    },
+    {
+      "relpath": "src/matches/domain/rules.py",
+      "sha256": "832533b8ffa27931ba8afab12f211d5508cf813aa76dc7bfad2bf84c207d7ce6"
+    }
+  ],
+  "known_gaps": [
+    "AsyncAPI/Arazzo do módulo seguem governança separada e não estão incluídos nesta fase do source graph.",
+    "competitionId é referência cruzada para módulo competitions — boundary explicitado em DR-MATCH-001.",
+    "homeTeamId e awayTeamId referenciam módulo teams — boundary explicitado em DR-MATCH-002.",
+    "lineupUserIds referenciam módulo users — boundary explicitado em DR-MATCH-001.",
+    "officialIncidentIds referenciam módulo incidents (scheduling futuro) — DEC-MATCHES-001: CRUD simples.",
+    "addPlayerToLineup usa operationId=addPlayerToLineup mas runtime usa PUT; patchMatch usa PATCH — mapeamento documentado em DEC-MATCHES-001."
+  ],
+  "module": "matches",
+  "next_stage_targets": [
+    "B3-001",
+    "B3-002"
+  ],
+  "outputs": [
+    "generated/source_graph/matches/matches.bundle.yaml",
+    "generated/source_graph/matches/matches.schema_contract_view.yaml",
+    "generated/source_graph/matches/matches.openapi_contract_view.yaml",
+    "generated/source_graph/matches/impact_report.json"
+  ],
+  "source_fingerprint": "97738af312c6c1b8bc681ad261f8ac87f96ccf81e3fd516f531c9af2ad056b81"
+}

--- a/generated/source_graph/matches/matches.bundle.yaml
+++ b/generated/source_graph/matches/matches.bundle.yaml
@@ -1,0 +1,494 @@
+artifact_id: HBTRACK_SOURCE_GRAPH_BUNDLE
+compiler: hbtrack_source_graph_compiler
+compiler_version: 0.1.0
+module: matches
+graph_root: docs/hbtrack/modulos/matches/graph
+inputs:
+- relpath: contracts/openapi/components/schemas/matches/match.yaml
+  sha256: f0d38d2f18f7d941921992617b0a46ea169eed2bb2e54d7b8f910350c5fdffbf
+- relpath: contracts/openapi/paths/matches.yaml
+  sha256: e21f3446a04b6024d370ba0bc0c0e43eaf275ff07159051dfb0421970f76f705
+- relpath: contracts/schemas/matches/.gitkeep
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+- relpath: contracts/schemas/matches/match.schema.json
+  sha256: 0794ae1db7742b9d9ddd297496342dc1caa0b8706143099b0dbf2d1b5b974c40
+- relpath: docs/_canon/MODULE_REGISTRY.yaml
+  sha256: 0f22b477ffaf2dec13c77adc469fd21cbbbf2fd2d6d1d5d6fcf672039972fedd
+- relpath: docs/_canon/MODULE_SOURCE_AUTHORITY_MATRIX.yaml
+  sha256: e01c6a21bafe91b849317c2749ffcea1ef1350a5afc2ed95caa5f1d5093a2680
+- relpath: docs/_canon/SOURCE_AUTHORITY_GRAPH.yaml
+  sha256: c7ff89bb7bc4e0e1851a3e6b1fd0aeaefbb0a0d5cdfb6a71aad0becfe042d8d1
+- relpath: docs/_canon/graph/global_policies.yaml
+  sha256: 4715e7504a06b32eecd83cf7e6a69f0ee762a28f3236614099fbff8138169fa2
+- relpath: docs/_canon/graph/global_rules.yaml
+  sha256: 02f75652679e4e5c981f177b6bc57f77e26b1a360e4452a2828bda448f349f07
+- relpath: docs/_canon/graph/lifecycle.yaml
+  sha256: 654844a0e8a2eb1f265f1c1dd5a20335a439facf300c56c137eb12c19e41a3c5
+- relpath: docs/hbtrack/modulos/matches/DOMAIN_RULES_MATCHES.md
+  sha256: 8f9679187b7b063fe6a7fed7e449c94fc7d09de6edaf63d58e3bfa84af901a5e
+- relpath: docs/hbtrack/modulos/matches/INVARIANTS_MATCHES.md
+  sha256: a392e05897096374b733f1c077cf9abced0318cec229ee360cdc73dd4a3e6a94
+- relpath: docs/hbtrack/modulos/matches/MODULE_SCOPE_MATCHES.md
+  sha256: d605c4a85bc62549eb35341562762a5f448e0a8ecdf70deb16560fc6e5296a23
+- relpath: docs/hbtrack/modulos/matches/PERMISSIONS_MATCHES.md
+  sha256: 836840067b8a17e124574c1ef80cda53d00751a95a9c3e4fb3661e9e05eb89bf
+- relpath: docs/hbtrack/modulos/matches/README.md
+  sha256: dc0e603582dfbb4d140a8322685624239e03554dbb6cc494dfb3c4f92ad0353a
+- relpath: docs/hbtrack/modulos/matches/TEST_MATRIX_MATCHES.md
+  sha256: e664b2877b1e330c6644b7794b3ccd898297cfeedebf9a33ddd5b339b6e9515a
+- relpath: docs/hbtrack/modulos/matches/graph/endpoints.yaml
+  sha256: 7d8b71cd02e7e1388d0bb96ba551fb906f72c0a7bfac8916f58c0b06746db057
+- relpath: docs/hbtrack/modulos/matches/graph/entities.yaml
+  sha256: dd21d79d79d917a5891deec838c5c0298900378f6d17b4eb7817b853e3c5938a
+- relpath: docs/hbtrack/modulos/matches/graph/errors.yaml
+  sha256: 1039e6a4ced36d117ea24d8a835cc1c7ea22dd5a16e6f9ef6343c881e259b6e8
+- relpath: docs/hbtrack/modulos/matches/graph/module_manifest.yaml
+  sha256: 3113bfb6ed3892fbede26961361bacf37606f511a0848366cecdd9b13613f7da
+- relpath: docs/hbtrack/modulos/matches/graph/test_obligations.yaml
+  sha256: c54aef8e24afe03b9a0a62e01f8d531110a35d24d7305bfa31ade47cd811843f
+- relpath: src/matches/api.py
+  sha256: da633cac6886fd69804bf2813593de53becff2bf2bfcdb2d3713921d86207ccf
+- relpath: src/matches/application/use_cases.py
+  sha256: b6173bb05caacfb5df41d4ac4fa0304b5921baf022997f4bf0d9a3b6716a5b24
+- relpath: src/matches/domain/entities.py
+  sha256: 4535c2eb63e55e9ec381f523c606070543c60c65cff856ca1fe0773056b1a6b0
+- relpath: src/matches/domain/rules.py
+  sha256: 832533b8ffa27931ba8afab12f211d5508cf813aa76dc7bfad2bf84c207d7ce6
+module_manifest:
+  version: 1.0.0
+  status: active
+  module: matches
+  phase: source_graph_rollout
+  global_refs:
+    source_authority_graph: ../../../../_canon/SOURCE_AUTHORITY_GRAPH.yaml
+    global_rules: ../../../../_canon/graph/global_rules.yaml
+    global_policies: ../../../../_canon/graph/global_policies.yaml
+    lifecycle: ../../../../_canon/graph/lifecycle.yaml
+    module_registry: ../../../../_canon/MODULE_REGISTRY.yaml
+    module_source_authority_matrix: ../../../../_canon/MODULE_SOURCE_AUTHORITY_MATRIX.yaml
+  module_docs:
+    readme: ../README.md
+    scope: ../MODULE_SCOPE_MATCHES.md
+    domain_rules: ../DOMAIN_RULES_MATCHES.md
+    invariants: ../INVARIANTS_MATCHES.md
+    permissions: ../PERMISSIONS_MATCHES.md
+    test_matrix: ../TEST_MATRIX_MATCHES.md
+  contract_surfaces:
+    openapi_paths: ../../../../../contracts/openapi/paths/matches.yaml
+    sovereign_schema_dir: ../../../../../contracts/schemas/matches/
+    primary_schema: ../../../../../contracts/schemas/matches/match.schema.json
+    openapi_projection: ../../../../../contracts/openapi/components/schemas/matches/match.yaml
+  runtime_surfaces:
+    api_router: ../../../../../src/matches/api.py
+    domain_entity: ../../../../../src/matches/domain/entities.py
+    domain_rules: ../../../../../src/matches/domain/rules.py
+    use_cases: ../../../../../src/matches/application/use_cases.py
+  structured_ir:
+    entities: ./entities.yaml
+    endpoints: ./endpoints.yaml
+    errors: ./errors.yaml
+    test_obligations: ./test_obligations.yaml
+  known_gaps:
+  - "AsyncAPI/Arazzo do m\xF3dulo seguem governan\xE7a separada e n\xE3o est\xE3o\
+    \ inclu\xEDdos nesta fase do source graph."
+  - "competitionId \xE9 refer\xEAncia cruzada para m\xF3dulo competitions \u2014 boundary\
+    \ explicitado em DR-MATCH-001."
+  - "homeTeamId e awayTeamId referenciam m\xF3dulo teams \u2014 boundary explicitado\
+    \ em DR-MATCH-002."
+  - "lineupUserIds referenciam m\xF3dulo users \u2014 boundary explicitado em DR-MATCH-001."
+  - "officialIncidentIds referenciam m\xF3dulo incidents (scheduling futuro) \u2014\
+    \ DEC-MATCHES-001: CRUD simples."
+  - "addPlayerToLineup usa operationId=addPlayerToLineup mas runtime usa PUT; patchMatch\
+    \ usa PATCH \u2014 mapeamento documentado em DEC-MATCHES-001."
+entities:
+  Match:
+    schema_ref: ../../../../../contracts/schemas/matches/match.schema.json
+    runtime_entity_ref: ../../../../../src/matches/domain/entities.py#Match
+    docs_refs:
+    - ../DOMAIN_RULES_MATCHES.md
+    - ../INVARIANTS_MATCHES.md
+    - ../PERMISSIONS_MATCHES.md
+    sovereign_fields:
+    - name: id
+      runtime_name: id
+      required: true
+      type: uuid_v4
+    - name: competitionId
+      runtime_name: competition_id
+      required: true
+      type: uuid_v4
+      constraints:
+      - "DR-MATCH-001: matches \xE9 soberano do registro oficial; competitionId \xE9\
+        \ obrigat\xF3rio"
+      - "INV-MATCH-001: campo obrigat\xF3rio"
+      - 'boundary: reference to competitions module'
+    - name: homeTeamId
+      runtime_name: home_team_id
+      required: true
+      type: uuid_v4
+      constraints:
+      - 'DR-MATCH-002: equipe mandante'
+      - "INV-MATCH-001: campo obrigat\xF3rio"
+      - 'INV-MATCH-002: homeTeamId != awayTeamId'
+      - 'boundary: reference to teams module'
+    - name: awayTeamId
+      runtime_name: away_team_id
+      required: true
+      type: uuid_v4
+      constraints:
+      - 'DR-MATCH-002: equipe visitante'
+      - "INV-MATCH-001: campo obrigat\xF3rio"
+      - 'INV-MATCH-002: homeTeamId != awayTeamId'
+      - 'boundary: reference to teams module'
+    - name: venueLabel
+      runtime_name: venue_label
+      required: false
+      type: string
+      constraints:
+      - 'nullable: true'
+      - 'maxLength: 200'
+    - name: statusLabel
+      runtime_name: status_label
+      required: true
+      type: enum
+      values:
+      - SCHEDULED
+      - PRE_MATCH
+      - FIRST_HALF
+      - HALF_TIME
+      - SECOND_HALF
+      - OVERTIME_1
+      - OVERTIME_2
+      - PENALTIES
+      - COMPLETED
+      - CANCELLED
+      constraints:
+      - 'DEC-MATCHES-002: 10 fases do ciclo de vida HBR-013'
+      - "default: SCHEDULED na cria\xE7\xE3o"
+    - name: scheduledAt
+      runtime_name: scheduled_at
+      required: true
+      type: datetime
+      constraints:
+      - "INV-MATCH-001: campo obrigat\xF3rio"
+    - name: startedAt
+      runtime_name: started_at
+      required: false
+      type: datetime
+      constraints:
+      - 'nullable: true'
+      - 'INV-MATCH-004: startedAt <= endedAt quando ambos presentes'
+    - name: endedAt
+      runtime_name: ended_at
+      required: false
+      type: datetime
+      constraints:
+      - 'nullable: true'
+      - 'INV-MATCH-004: startedAt <= endedAt quando ambos presentes'
+    - name: homeScore
+      runtime_name: home_score
+      required: false
+      type: integer
+      constraints:
+      - 'nullable: true'
+      - 'minimum: 0'
+      - 'INV-MATCH-003: homeScore >= 0 quando presente'
+    - name: awayScore
+      runtime_name: away_score
+      required: false
+      type: integer
+      constraints:
+      - 'nullable: true'
+      - 'minimum: 0'
+      - 'INV-MATCH-003: awayScore >= 0 quando presente'
+    - name: lineupUserIds
+      runtime_name: lineup_user_ids
+      required: true
+      type: array_of_uuid
+      constraints:
+      - 'uniqueItems: true'
+      - 'INV-MATCH-005: sem duplicatas'
+      - 'HBR-008: max 16 por equipe'
+      - 'boundary: reference to users module'
+    - name: officialIncidentIds
+      runtime_name: official_incident_ids
+      required: true
+      type: array_of_uuid
+      constraints:
+      - 'uniqueItems: true'
+      - 'INV-MATCH-005: sem duplicatas'
+      - "DEC-MATCHES-001: CRUD simples; s\xFAmula alimentada pelo operador p\xF3s-jogo"
+    - name: refereeNames
+      runtime_name: referee_names
+      required: true
+      type: array_of_string
+      constraints:
+      - 'uniqueItems: true'
+      - 'INV-MATCH-005: sem duplicatas'
+      - "DR-MATCH-003: \xE1rbitros s\xE3o nomes simples, n\xE3o entidades do dom\xED\
+        nio"
+    - name: createdAt
+      runtime_name: created_at
+      required: true
+      type: datetime
+    - name: updatedAt
+      runtime_name: updated_at
+      required: true
+      type: datetime
+    domain_enums:
+    - name: RoleLabel
+      values:
+      - admin
+      - coordinator
+      - coach
+      - athlete
+      - member
+      source: ADR-008 / SYSTEM_SCOPE.md
+    - name: MatchStatus
+      values:
+      - SCHEDULED
+      - PRE_MATCH
+      - FIRST_HALF
+      - HALF_TIME
+      - SECOND_HALF
+      - OVERTIME_1
+      - OVERTIME_2
+      - PENALTIES
+      - COMPLETED
+      - CANCELLED
+      source: DEC-MATCHES-002 / HBR-013
+    invariants:
+    - id: INV-MATCH-001
+      rule: "id, competition_id, home_team_id, away_team_id, scheduled_at s\xE3o obrigat\xF3\
+        rios."
+    - id: INV-MATCH-002
+      rule: home_team_id deve ser diferente de away_team_id.
+    - id: INV-MATCH-003
+      rule: home_score e away_score devem ser >= 0 quando presentes.
+    - id: INV-MATCH-004
+      rule: started_at deve ser <= ended_at quando ambos presentes.
+    - id: INV-MATCH-005
+      rule: "lineup_user_ids, official_incident_ids e referee_names n\xE3o podem ter\
+        \ duplicatas."
+endpoints:
+- operation_id: listMatches
+  method: GET
+  path: /matches
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/get
+  runtime_handler_ref: ../../../../../src/matches/api.py#list_matches
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#ListMatches
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  - athlete
+  - member
+  roles_denied: []
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 401
+  - 403
+  - 500
+- operation_id: createMatch
+  method: POST
+  path: /matches
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/post
+  runtime_handler_ref: ../../../../../src/matches/api.py#create_match
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#CreateMatch
+  roles_allowed:
+  - admin
+  - coordinator
+  roles_denied:
+  - coach
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 201
+  - 400
+  - 401
+  - 403
+  - 409
+  - 500
+- operation_id: getMatch
+  method: GET
+  path: /matches/{matchId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/get
+  runtime_handler_ref: ../../../../../src/matches/api.py#get_match
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#GetMatch
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  - athlete
+  - member
+  roles_denied: []
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 401
+  - 403
+  - 404
+  - 500
+- operation_id: patchMatch
+  method: PATCH
+  path: /matches/{matchId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/patch
+  runtime_handler_ref: ../../../../../src/matches/api.py#patch_match
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#PatchMatch
+  roles_allowed:
+  - admin
+  - coordinator
+  roles_denied:
+  - coach
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 400
+  - 401
+  - 403
+  - 404
+  - 409
+  - 500
+- operation_id: addPlayerToLineup
+  method: PUT
+  path: /matches/{matchId}/lineup/{userId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/put
+  runtime_handler_ref: ../../../../../src/matches/api.py#add_player_to_lineup
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#AddPlayerToLineup
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  roles_denied:
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 400
+  - 401
+  - 403
+  - 404
+  - 409
+  - 500
+- operation_id: removePlayerFromLineup
+  method: DELETE
+  path: /matches/{matchId}/lineup/{userId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/delete
+  runtime_handler_ref: ../../../../../src/matches/api.py#remove_player_from_lineup
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#RemovePlayerFromLineup
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  roles_denied:
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 400
+  - 401
+  - 403
+  - 404
+  - 409
+  - 500
+errors:
+- id: ERR-MATCH-401-UNAUTHENTICATED
+  kind: transport
+  http_status: 401
+  source_ref: ../../../../../src/matches/api.py#_role
+  operations:
+  - listMatches
+  - createMatch
+  - getMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-403-INSUFFICIENT-PRIVILEGE
+  kind: domain
+  http_status: 403
+  exception_ref: ../../../../../src/matches/domain/rules.py#InsufficientPrivilege
+  operations:
+  - createMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-404-NOT-FOUND
+  kind: domain
+  http_status: 404
+  exception_ref: ../../../../../src/matches/domain/rules.py#MatchNotFound
+  operations:
+  - getMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-400-VALIDATION
+  kind: domain
+  http_status: 400
+  source_ref: ../../../../../src/matches/domain/entities.py#validate_invariants
+  operations:
+  - createMatch
+  - patchMatch
+- id: ERR-MATCH-409-STATE-ERROR
+  kind: domain
+  http_status: 409
+  exception_ref: ../../../../../src/matches/domain/rules.py#MatchStateError
+  operations:
+  - createMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-500-INTERNAL
+  kind: transport
+  http_status: 500
+  source_ref: ../../../../../src/matches/api.py#list_matches
+  operations:
+  - listMatches
+  - createMatch
+  - getMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+test_obligations:
+- id: MATCH-TO-001
+  scope: sovereign_schema
+  artifact_ref: ../../../../../contracts/schemas/matches/match.schema.json
+  verification: JSON Schema validation via contract gates
+  evidence_refs:
+  - ../../../../../_reports/contract_gates/latest.json
+- id: MATCH-TO-002
+  scope: openapi_contract
+  artifact_ref: ../../../../../contracts/openapi/paths/matches.yaml
+  verification: OpenAPI lint and contract-gate validation
+  evidence_refs:
+  - ../../../../../_reports/contract_gates/latest.json
+- id: MATCH-TO-003
+  scope: domain_invariants_and_permissions
+  artifact_ref: ../../../../../src/matches/tests/unit/test_matches_domain.py
+  covers:
+  - INV-MATCH-001
+  - INV-MATCH-002
+  - INV-MATCH-003
+  - INV-MATCH-004
+  - INV-MATCH-005
+  - DR-MATCH-001
+  - DR-MATCH-002
+  - DR-MATCH-003
+  - DR-MATCH-004
+  - DR-MATCH-005
+  verification: Domain unit tests enforcing invariants, boundary rules and permission
+    checks
+  evidence_refs:
+  - ../../../../../src/matches/tests/unit/test_matches_domain.py
+- id: MATCH-TO-004
+  scope: source_graph_integrity
+  artifact_ref: ../../../../../tests/pipeline_gates/test_matches_source_graph_integrity.py
+  verification: Pipeline gate enforces parity between graph, docs, contracts and runtime
+    refs
+  evidence_refs:
+  - ../../../../../tests/pipeline_gates/test_matches_source_graph_integrity.py

--- a/generated/source_graph/matches/matches.openapi_contract_view.yaml
+++ b/generated/source_graph/matches/matches.openapi_contract_view.yaml
@@ -1,0 +1,189 @@
+artifact_id: HBTRACK_SOURCE_GRAPH_OPENAPI_CONTRACT_VIEW
+compiler: hbtrack_source_graph_compiler
+compiler_version: 0.1.0
+module: matches
+openapi_paths_ref: contracts/openapi/paths/matches.yaml
+operations:
+- operation_id: listMatches
+  method: GET
+  path: /matches
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/get
+  runtime_handler_ref: ../../../../../src/matches/api.py#list_matches
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#ListMatches
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  - athlete
+  - member
+  roles_denied: []
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 401
+  - 403
+  - 500
+- operation_id: createMatch
+  method: POST
+  path: /matches
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/post
+  runtime_handler_ref: ../../../../../src/matches/api.py#create_match
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#CreateMatch
+  roles_allowed:
+  - admin
+  - coordinator
+  roles_denied:
+  - coach
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 201
+  - 400
+  - 401
+  - 403
+  - 409
+  - 500
+- operation_id: getMatch
+  method: GET
+  path: /matches/{matchId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/get
+  runtime_handler_ref: ../../../../../src/matches/api.py#get_match
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#GetMatch
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  - athlete
+  - member
+  roles_denied: []
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 401
+  - 403
+  - 404
+  - 500
+- operation_id: patchMatch
+  method: PATCH
+  path: /matches/{matchId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/patch
+  runtime_handler_ref: ../../../../../src/matches/api.py#patch_match
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#PatchMatch
+  roles_allowed:
+  - admin
+  - coordinator
+  roles_denied:
+  - coach
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 400
+  - 401
+  - 403
+  - 404
+  - 409
+  - 500
+- operation_id: addPlayerToLineup
+  method: PUT
+  path: /matches/{matchId}/lineup/{userId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/put
+  runtime_handler_ref: ../../../../../src/matches/api.py#add_player_to_lineup
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#AddPlayerToLineup
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  roles_denied:
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 400
+  - 401
+  - 403
+  - 404
+  - 409
+  - 500
+- operation_id: removePlayerFromLineup
+  method: DELETE
+  path: /matches/{matchId}/lineup/{userId}
+  openapi_ref: ../../../../../contracts/openapi/paths/matches.yaml#/matches/{matchId}/lineup/{userId}/delete
+  runtime_handler_ref: ../../../../../src/matches/api.py#remove_player_from_lineup
+  use_case_ref: ../../../../../src/matches/application/use_cases.py#RemovePlayerFromLineup
+  roles_allowed:
+  - admin
+  - coordinator
+  - coach
+  roles_denied:
+  - athlete
+  - member
+  owner_scoped_roles: []
+  response_codes:
+  - 200
+  - 400
+  - 401
+  - 403
+  - 404
+  - 409
+  - 500
+errors:
+- id: ERR-MATCH-401-UNAUTHENTICATED
+  kind: transport
+  http_status: 401
+  source_ref: ../../../../../src/matches/api.py#_role
+  operations:
+  - listMatches
+  - createMatch
+  - getMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-403-INSUFFICIENT-PRIVILEGE
+  kind: domain
+  http_status: 403
+  exception_ref: ../../../../../src/matches/domain/rules.py#InsufficientPrivilege
+  operations:
+  - createMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-404-NOT-FOUND
+  kind: domain
+  http_status: 404
+  exception_ref: ../../../../../src/matches/domain/rules.py#MatchNotFound
+  operations:
+  - getMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-400-VALIDATION
+  kind: domain
+  http_status: 400
+  source_ref: ../../../../../src/matches/domain/entities.py#validate_invariants
+  operations:
+  - createMatch
+  - patchMatch
+- id: ERR-MATCH-409-STATE-ERROR
+  kind: domain
+  http_status: 409
+  exception_ref: ../../../../../src/matches/domain/rules.py#MatchStateError
+  operations:
+  - createMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup
+- id: ERR-MATCH-500-INTERNAL
+  kind: transport
+  http_status: 500
+  source_ref: ../../../../../src/matches/api.py#list_matches
+  operations:
+  - listMatches
+  - createMatch
+  - getMatch
+  - patchMatch
+  - addPlayerToLineup
+  - removePlayerFromLineup

--- a/generated/source_graph/matches/matches.schema_contract_view.yaml
+++ b/generated/source_graph/matches/matches.schema_contract_view.yaml
@@ -1,0 +1,153 @@
+artifact_id: HBTRACK_SOURCE_GRAPH_SCHEMA_CONTRACT_VIEW
+compiler: hbtrack_source_graph_compiler
+compiler_version: 0.1.0
+module: matches
+entity: Match
+primary_entity: Match
+primary_schema_ref: contracts/schemas/matches/match.schema.json
+openapi_projection_ref: contracts/openapi/components/schemas/matches/match.yaml
+required: &id001
+- id
+- competitionId
+- homeTeamId
+- awayTeamId
+- statusLabel
+- scheduledAt
+- lineupUserIds
+- officialIncidentIds
+- refereeNames
+- createdAt
+- updatedAt
+sovereign_fields: &id002
+- name: id
+  runtime_name: id
+  required: true
+  type: uuid_v4
+- name: competitionId
+  runtime_name: competition_id
+  required: true
+  type: uuid_v4
+  constraints:
+  - "DR-MATCH-001: matches \xE9 soberano do registro oficial; competitionId \xE9 obrigat\xF3\
+    rio"
+  - "INV-MATCH-001: campo obrigat\xF3rio"
+  - 'boundary: reference to competitions module'
+- name: homeTeamId
+  runtime_name: home_team_id
+  required: true
+  type: uuid_v4
+  constraints:
+  - 'DR-MATCH-002: equipe mandante'
+  - "INV-MATCH-001: campo obrigat\xF3rio"
+  - 'INV-MATCH-002: homeTeamId != awayTeamId'
+  - 'boundary: reference to teams module'
+- name: awayTeamId
+  runtime_name: away_team_id
+  required: true
+  type: uuid_v4
+  constraints:
+  - 'DR-MATCH-002: equipe visitante'
+  - "INV-MATCH-001: campo obrigat\xF3rio"
+  - 'INV-MATCH-002: homeTeamId != awayTeamId'
+  - 'boundary: reference to teams module'
+- name: venueLabel
+  runtime_name: venue_label
+  required: false
+  type: string
+  constraints:
+  - 'nullable: true'
+  - 'maxLength: 200'
+- name: statusLabel
+  runtime_name: status_label
+  required: true
+  type: enum
+  values:
+  - SCHEDULED
+  - PRE_MATCH
+  - FIRST_HALF
+  - HALF_TIME
+  - SECOND_HALF
+  - OVERTIME_1
+  - OVERTIME_2
+  - PENALTIES
+  - COMPLETED
+  - CANCELLED
+  constraints:
+  - 'DEC-MATCHES-002: 10 fases do ciclo de vida HBR-013'
+  - "default: SCHEDULED na cria\xE7\xE3o"
+- name: scheduledAt
+  runtime_name: scheduled_at
+  required: true
+  type: datetime
+  constraints:
+  - "INV-MATCH-001: campo obrigat\xF3rio"
+- name: startedAt
+  runtime_name: started_at
+  required: false
+  type: datetime
+  constraints:
+  - 'nullable: true'
+  - 'INV-MATCH-004: startedAt <= endedAt quando ambos presentes'
+- name: endedAt
+  runtime_name: ended_at
+  required: false
+  type: datetime
+  constraints:
+  - 'nullable: true'
+  - 'INV-MATCH-004: startedAt <= endedAt quando ambos presentes'
+- name: homeScore
+  runtime_name: home_score
+  required: false
+  type: integer
+  constraints:
+  - 'nullable: true'
+  - 'minimum: 0'
+  - 'INV-MATCH-003: homeScore >= 0 quando presente'
+- name: awayScore
+  runtime_name: away_score
+  required: false
+  type: integer
+  constraints:
+  - 'nullable: true'
+  - 'minimum: 0'
+  - 'INV-MATCH-003: awayScore >= 0 quando presente'
+- name: lineupUserIds
+  runtime_name: lineup_user_ids
+  required: true
+  type: array_of_uuid
+  constraints:
+  - 'uniqueItems: true'
+  - 'INV-MATCH-005: sem duplicatas'
+  - 'HBR-008: max 16 por equipe'
+  - 'boundary: reference to users module'
+- name: officialIncidentIds
+  runtime_name: official_incident_ids
+  required: true
+  type: array_of_uuid
+  constraints:
+  - 'uniqueItems: true'
+  - 'INV-MATCH-005: sem duplicatas'
+  - "DEC-MATCHES-001: CRUD simples; s\xFAmula alimentada pelo operador p\xF3s-jogo"
+- name: refereeNames
+  runtime_name: referee_names
+  required: true
+  type: array_of_string
+  constraints:
+  - 'uniqueItems: true'
+  - 'INV-MATCH-005: sem duplicatas'
+  - "DR-MATCH-003: \xE1rbitros s\xE3o nomes simples, n\xE3o entidades do dom\xEDnio"
+- name: createdAt
+  runtime_name: created_at
+  required: true
+  type: datetime
+- name: updatedAt
+  runtime_name: updated_at
+  required: true
+  type: datetime
+runtime_extension_fields: []
+entities:
+  Match:
+    schema_ref: contracts/schemas/matches/match.schema.json
+    required: *id001
+    sovereign_fields: *id002
+    runtime_extension_fields: []

--- a/tests/pipeline_gates/test_context_bundle_matches.py
+++ b/tests/pipeline_gates/test_context_bundle_matches.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from scripts.compile.compile_context_bundle import check_expected, compile_expected, write_expected
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_OUTPUTS = {
+    "compiled_context/matches/FT-035.json",
+}
+
+
+def test_compile_expected_matches_context_bundle_emits_required_outputs():
+    expected = compile_expected(REPO_ROOT, "matches")
+    assert {item.relpath for item in expected} == EXPECTED_OUTPUTS
+
+    ft035_content = next(item.content for item in expected if item.relpath.endswith("FT-035.json"))
+    payload = json.loads(ft035_content)
+    assert payload["artifact_id"] == "HBTRACK_MODULE_FEATURE_CONTEXT_BUNDLE"
+    assert payload["compiler"] == "hbtrack_context_bundle_compiler"
+    assert payload["module"] == "matches"
+    assert payload["feature"]["id"] == "FT-035"
+    assert payload["feature"]["status"] == "implemented"
+    assert payload["feature"]["contracts"] == ["contracts/openapi/paths/matches.yaml"]
+    assert "GET /matches" in payload["feature"]["endpoints"]
+    assert "PUT /matches/{matchId}/lineup/{userId}" in payload["feature"]["endpoints"]
+    assert payload["source_graph"]["impact_report"]["blocked_partial_update"] is True
+    assert "src/matches/api.py" in payload["implementation_targets"]["canonical_runtime"]
+
+
+def test_compile_expected_matches_context_bundle_is_deterministic():
+    first = compile_expected(REPO_ROOT, "matches")
+    second = compile_expected(REPO_ROOT, "matches")
+    assert first == second
+
+
+def test_write_and_check_expected_matches_context_bundle_roundtrip(tmp_path: Path):
+    expected = compile_expected(REPO_ROOT, "matches")
+    written = write_expected(tmp_path, expected)
+
+    assert set(written) == EXPECTED_OUTPUTS
+    assert check_expected(tmp_path, expected) == []
+
+
+def test_context_bundle_cli_check_passes_for_matches_and_all():
+    matches_result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "compile" / "compile_context_bundle.py"),
+            "--module",
+            "matches",
+            "--check",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert matches_result.returncode == 0, matches_result.stdout + matches_result.stderr
+    matches_payload = json.loads(matches_result.stdout)
+    assert matches_payload["status"] == "PASS"
+    assert sorted(matches_payload["features"]) == ["FT-035"]
+
+    batch_result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "compile" / "compile_context_bundle.py"),
+            "--all",
+            "--check",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert batch_result.returncode == 0, batch_result.stdout + batch_result.stderr
+    batch_payload = json.loads(batch_result.stdout)
+    assert batch_payload["status"] == "PASS"
+    assert "matches" in {batch_payload.get("module")} | set(batch_payload.get("modules", []))
+
+
+def test_matches_sync_manifest_requires_context_bundle():
+    sync_manifest = yaml.safe_load((REPO_ROOT / "docs" / "_canon" / "SYNC_MANIFEST.yaml").read_text(encoding="utf-8"))
+    rule = next(item for item in sync_manifest["rules"] if item["rule_id"] == "MATCHES_SOURCE_GRAPH_SYNC")
+
+    assert "compiled_context/matches/FT-035.json" in rule["required_consumers"]
+    assert "python3 scripts/compile/compile_context_bundle.py --module matches --check --format json" in rule["validation_commands"]
+    assert "python3 -m pytest tests/pipeline_gates/test_matches_source_graph_integrity.py tests/pipeline_gates/test_source_graph_compiler_matches.py tests/pipeline_gates/test_context_bundle_matches.py -q" in rule["validation_commands"]

--- a/tests/pipeline_gates/test_matches_source_graph_integrity.py
+++ b/tests/pipeline_gates/test_matches_source_graph_integrity.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRAPH_ROOT = REPO_ROOT / "docs" / "hbtrack" / "modulos" / "matches" / "graph"
+
+
+def _load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve(ref: str) -> Path:
+    target = (GRAPH_ROOT / ref).resolve()
+    assert target.exists(), f"referência ausente no source graph: {ref}"
+    return target
+
+
+def _resolve_symbol(ref: str) -> tuple[Path, str]:
+    path_str, symbol = ref.split("#", 1)
+    return _resolve(path_str), symbol
+
+
+def _operation_ids_from_openapi(path_doc: dict) -> list[str]:
+    operation_ids: list[str] = []
+    for path_item in path_doc.values():
+        for method_doc in path_item.values():
+            if isinstance(method_doc, dict) and "operationId" in method_doc:
+                operation_ids.append(method_doc["operationId"])
+    return operation_ids
+
+
+def test_matches_graph_files_exist_and_are_active():
+    expected = {
+        "module_manifest.yaml",
+        "entities.yaml",
+        "endpoints.yaml",
+        "errors.yaml",
+        "test_obligations.yaml",
+    }
+    present = {path.name for path in GRAPH_ROOT.glob("*.yaml")}
+    assert expected <= present
+
+    for filename in expected:
+        payload = _load_yaml(GRAPH_ROOT / filename)
+        assert payload["status"] == "active"
+        assert payload["module"] == "matches"
+
+
+def test_matches_module_manifest_refs_resolve():
+    manifest = _load_yaml(GRAPH_ROOT / "module_manifest.yaml")
+
+    for section in ("module_docs", "contract_surfaces", "runtime_surfaces", "structured_ir"):
+        for ref in manifest[section].values():
+            _resolve(ref)
+
+    assert manifest["phase"] == "source_graph_rollout"
+    assert manifest["known_gaps"]
+
+
+def test_matches_entities_graph_matches_schema_and_runtime():
+    entities = _load_yaml(GRAPH_ROOT / "entities.yaml")["entities"]
+    entity = entities["Match"]
+    schema = _load_json(_resolve(entity["schema_ref"]))
+    entity_file, symbol = _resolve_symbol(entity["runtime_entity_ref"])
+    entity_source = entity_file.read_text(encoding="utf-8")
+
+    assert entity_file.name == "entities.py"
+    assert f"class {symbol}" in entity_source
+    assert entity["schema_ref"].endswith("match.schema.json")
+
+    graph_sovereign_names = [field["name"] for field in entity["sovereign_fields"]]
+    assert graph_sovereign_names == list(schema["properties"].keys())
+
+    graph_required = sorted(field["name"] for field in entity["sovereign_fields"] if field["required"])
+    assert graph_required == sorted(schema["required"])
+
+    for field in entity["sovereign_fields"]:
+        assert field["runtime_name"] in entity_source
+
+
+def test_matches_endpoints_graph_matches_openapi_and_runtime_refs():
+    endpoints = _load_yaml(GRAPH_ROOT / "endpoints.yaml")["endpoints"]
+    openapi_paths = _load_yaml(REPO_ROOT / "contracts" / "openapi" / "paths" / "matches.yaml")
+
+    graph_operation_ids = [entry["operation_id"] for entry in endpoints]
+    assert sorted(graph_operation_ids) == sorted(_operation_ids_from_openapi(openapi_paths))
+
+    for entry in endpoints:
+        assert entry["method"] in {"GET", "POST", "PUT", "PATCH", "DELETE"}
+        assert isinstance(entry["response_codes"], list) and entry["response_codes"]
+        _resolve(entry["openapi_ref"].split("#", 1)[0])
+
+        handler_file, handler_symbol = _resolve_symbol(entry["runtime_handler_ref"])
+        assert f"def {handler_symbol}" in handler_file.read_text(encoding="utf-8")
+
+        use_case_file, use_case_symbol = _resolve_symbol(entry["use_case_ref"])
+        assert f"class {use_case_symbol}" in use_case_file.read_text(encoding="utf-8")
+
+
+def test_matches_errors_graph_maps_to_real_exceptions_and_operations():
+    endpoints = _load_yaml(GRAPH_ROOT / "endpoints.yaml")["endpoints"]
+    operation_ids = {entry["operation_id"] for entry in endpoints}
+    errors = _load_yaml(GRAPH_ROOT / "errors.yaml")["errors"]
+
+    for error in errors:
+        assert set(error["operations"]) <= operation_ids
+        if "exception_ref" in error:
+            exc_file, exc_symbol = _resolve_symbol(error["exception_ref"])
+            assert f"class {exc_symbol}" in exc_file.read_text(encoding="utf-8")
+        if "source_ref" in error:
+            src_file, src_symbol = _resolve_symbol(error["source_ref"])
+            assert src_symbol in src_file.read_text(encoding="utf-8")
+
+
+def test_matches_test_obligations_cover_graph_contracts_and_runtime():
+    obligations = _load_yaml(GRAPH_ROOT / "test_obligations.yaml")["obligations"]
+    obligation_ids = {item["id"] for item in obligations}
+    assert obligation_ids == {
+        "MATCH-TO-001",
+        "MATCH-TO-002",
+        "MATCH-TO-003",
+        "MATCH-TO-004",
+    }
+
+    for obligation in obligations:
+        artifact = _resolve(obligation["artifact_ref"])
+        assert artifact.exists()
+        for evidence_ref in obligation["evidence_refs"]:
+            _resolve(evidence_ref)
+
+
+def test_matches_module_docs_and_manifest_reference_source_graph():
+    readme = (REPO_ROOT / "docs" / "hbtrack" / "modulos" / "matches" / "README.md").read_text(encoding="utf-8")
+    domain_rules = (REPO_ROOT / "docs" / "hbtrack" / "modulos" / "matches" / "DOMAIN_RULES_MATCHES.md").read_text(encoding="utf-8")
+    test_matrix = (REPO_ROOT / "docs" / "hbtrack" / "modulos" / "matches" / "TEST_MATRIX_MATCHES.md").read_text(encoding="utf-8")
+    manifest = _load_yaml(REPO_ROOT / "docs" / "_canon" / "DOC_USAGE_MANIFEST.yaml")
+
+    for ref in (
+        "graph/module_manifest.yaml",
+        "graph/entities.yaml",
+        "graph/endpoints.yaml",
+        "graph/errors.yaml",
+        "graph/test_obligations.yaml",
+    ):
+        assert ref in readme
+
+    assert "graph/entities.yaml" in domain_rules
+    assert "graph/endpoints.yaml" in domain_rules
+    assert "graph/errors.yaml" in domain_rules
+    assert "graph/test_obligations.yaml" in test_matrix
+
+    matches_graph_entry = next(entry for entry in manifest["entries"] if entry["rule_id"] == "HBTRACK_MATCHES_GRAPH")
+    covered = set()
+    for pattern in matches_graph_entry["path_globs"]:
+        covered |= {
+            path.relative_to(REPO_ROOT).as_posix()
+            for path in REPO_ROOT.glob(pattern)
+            if path.is_file()
+        }
+    assert covered == {
+        "docs/hbtrack/modulos/matches/graph/module_manifest.yaml",
+        "docs/hbtrack/modulos/matches/graph/entities.yaml",
+        "docs/hbtrack/modulos/matches/graph/endpoints.yaml",
+        "docs/hbtrack/modulos/matches/graph/errors.yaml",
+        "docs/hbtrack/modulos/matches/graph/test_obligations.yaml",
+    }

--- a/tests/pipeline_gates/test_source_graph_compiler_matches.py
+++ b/tests/pipeline_gates/test_source_graph_compiler_matches.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from scripts.compile.compile_source_graph import check_expected, compile_expected, write_expected
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_OUTPUTS = {
+    "generated/source_graph/matches/matches.bundle.yaml",
+    "generated/source_graph/matches/matches.schema_contract_view.yaml",
+    "generated/source_graph/matches/matches.openapi_contract_view.yaml",
+    "generated/source_graph/matches/impact_report.json",
+}
+
+
+def test_compile_expected_matches_emits_required_outputs():
+    expected = compile_expected(REPO_ROOT, "matches")
+    assert {item.relpath for item in expected} == EXPECTED_OUTPUTS
+
+    bundle = next(item for item in expected if item.relpath.endswith("matches.bundle.yaml"))
+    bundle_data = yaml.safe_load(bundle.content)
+    assert set(bundle_data["entities"].keys()) == {"Match"}
+
+    schema_view = next(item for item in expected if item.relpath.endswith("matches.schema_contract_view.yaml"))
+    schema_data = yaml.safe_load(schema_view.content)
+    assert schema_data["primary_entity"] == "Match"
+
+    impact = next(item for item in expected if item.relpath.endswith("impact_report.json"))
+    impact_data = json.loads(impact.content)
+    assert impact_data["blocked_partial_update"] is True
+
+
+def test_compile_expected_matches_is_deterministic():
+    first = compile_expected(REPO_ROOT, "matches")
+    second = compile_expected(REPO_ROOT, "matches")
+    assert first == second
+
+
+def test_write_and_check_expected_matches_roundtrip(tmp_path: Path):
+    expected = compile_expected(REPO_ROOT, "matches")
+    written = write_expected(tmp_path, expected)
+
+    assert set(written) == EXPECTED_OUTPUTS
+    assert check_expected(tmp_path, expected) == []
+
+
+def test_compile_source_graph_cli_check_passes_for_matches_and_all():
+    matches_result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "compile" / "compile_source_graph.py"),
+            "--module",
+            "matches",
+            "--check",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert matches_result.returncode == 0, matches_result.stdout + matches_result.stderr
+    matches_payload = json.loads(matches_result.stdout)
+    assert matches_payload["status"] == "PASS"
+    assert matches_payload["module"] == "matches"
+
+    all_result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "compile" / "compile_source_graph.py"),
+            "--all",
+            "--check",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert all_result.returncode == 0, all_result.stdout + all_result.stderr
+    all_payload = json.loads(all_result.stdout)
+    assert all_payload["status"] == "PASS"
+    assert "matches" in all_payload.get("modules", [])


### PR DESCRIPTION
## B10-001 — Módulo `matches`

### O que foi feito
- **Fix FEATURE_REGISTRY**: FT-035 corrigido — `POST→PUT` para `addPlayerToLineup`, adicionados `PATCH /matches/{matchId}` e `DELETE /matches/{matchId}/lineup/{userId}`
- **Source graph**: 5 YAMLs (`module_manifest`, `entities/Match/16 campos`, `endpoints/6 ops`, `errors/6 entradas`, `test_obligations/MATCH-TO-001..004`)
- **compile_source_graph --module matches** → PASS (4 artefatos gerados)
- **compile_source_graph --all --check** → PASS (6 módulos)
- **SYNC_MANIFEST**: bloco `MATCHES_SOURCE_GRAPH_SYNC` adicionado
- **DOC_USAGE_MANIFEST**: bloco `HBTRACK_MATCHES_GRAPH` adicionado
- **compile_context_bundle --module matches** → PASS (FT-035.json)
- **compile_context_bundle --all** → PASS (6 módulos)
- **Docs**: README + DOMAIN_RULES_MATCHES + TEST_MATRIX_MATCHES (seção Source Graph, TM-005)
- **3 test files** → **16 testes PASS** (integrity/compiler/context_bundle)

### Endpoints (6)
| Method | Path | Use Case |
|--------|------|----------|
| GET | /matches | ListMatches |
| POST | /matches | CreateMatch |
| GET | /matches/{matchId} | GetMatch |
| PATCH | /matches/{matchId} | PatchMatch |
| PUT | /matches/{matchId}/lineup/{userId} | AddPlayerToLineup |
| DELETE | /matches/{matchId}/lineup/{userId} | RemovePlayerFromLineup |

### FT
- FT-035: Agendar Partidas e Gerenciar Escalações