### PR TITLE
fix(ci): increase schemathesis timeout from 120s to 300s per-module

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
-data_ultima_sessao: "2026-04-11"
-branch_ativo: chore/saneamento-completo-23-23
+data_ultima_sessao: "2026-04-12"
+branch_ativo: main
 modo_operacao: ROADMAP
 ci_status: PASS
 modulo_foco: training
@@ -10,7 +10,7 @@ task_type: execute_roadmap_phase
 boot_profile_id: roadmap_execution
 task_id: SANEAMENTO-23-23
 resultado: DONE
-proxima_acao_permitida: "Deploy branch atual para staging (conterá prefixo /training/ e respectivos 500 responses)."
+proxima_acao_permitida: "1. Re-trigger deploy workflow após fix do timeout schemathesis (120s→300s) 2. Liga compliance testing contra staging 3. Marcar Fase 4 DONE"
 bloqueios_ativos: []
 evidence_paths:
   - contracts/openapi/openapi.yaml

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -6242,7 +6242,7 @@ def _g11_http_runtime_contract(root: pathlib.Path) -> dict:
     module_filter = os.environ.get("HB_SCHEMATHESIS_MODULE", "").strip()
     if module_filter:
         path_regex = rf"^/api/{re.escape(module_filter)}/"
-        timeout_sec = 120
+        timeout_sec = 300
     else:
         path_regex = r"^/api/(auth|users|teams|seasons|training)/"
         timeout_sec = 300


### PR DESCRIPTION
## Summary
Training module now has 36 endpoints (after Phase 4 A1+B1) and exceeds the 120s per-module timeout during HTTP_RUNTIME_CONTRACT_GATE validation.

**Solution**: Increased per-module schemathesis timeout from 120s to 300s.

## Test Plan
- Re-trigger deploy workflow
- Verify Contract Conformance stage passes for training module