### PR TITLE
fix(ci): split training module into 3 sub-groups to prevent timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -363,7 +363,9 @@ jobs:
           - users
           - teams
           - seasons
-          - training
+          - training-core
+          - training-ops
+          - training-intelligence
     env:
       HB_STAGING_URL: https://staging.handballtrack.app
       HB_SCHEMATHESIS_MODULE: ${{ matrix.module }}

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -6247,8 +6247,8 @@ def _g11_http_runtime_contract(root: pathlib.Path) -> dict:
         path_regex = r"^/api/(auth|users|teams|seasons|training)/"
         timeout_sec = 300
 
-    # Reduzir complexidade para training (muitos endpoints) - usar max-examples menor
-    max_examples = "2" if module_filter == "training" else "5"
+    # Reduzir complexidade para training (muitos endpoints) - usar max-examples=1
+    max_examples = "1" if module_filter == "training" else "5"
 
     cmd = [
         st_cli, "run",

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -6239,16 +6239,28 @@ def _g11_http_runtime_contract(root: pathlib.Path) -> dict:
                    _ms(t0))
     # Suporte a execução por módulo: HB_SCHEMATHESIS_MODULE=<module> reduz o escopo a um único
     # path prefix e permite paralelismo via matrix no CI (cada job testa 1 módulo).
+    # Training dividido em 3 sub-grupos para evitar timeout (36 endpoints total).
     module_filter = os.environ.get("HB_SCHEMATHESIS_MODULE", "").strip()
-    if module_filter:
+
+    # Mapeamento de sub-grupos training para path patterns específicos
+    training_subgroups = {
+        "training-core": r"^/api/training/(mesocycles|microcycles|training-sessions)($|/[^/]+$)",
+        "training-ops": r"^/api/training/training-sessions/[^/]+/(archive|cancel|complete|publish|start|unpublish|attendance|wellness-pre|wellness-post)",
+        "training-intelligence": r"^/api/training/training-sessions/[^/]+/(feedback-threads|messages|attention-queue|recommendations|suggestions|ineligibility|load-chart|blocks|objectives|execution-records)",
+    }
+
+    if module_filter in training_subgroups:
+        path_regex = training_subgroups[module_filter]
+        timeout_sec = 300
+        max_examples = "1"
+    elif module_filter:
         path_regex = rf"^/api/{re.escape(module_filter)}/"
         timeout_sec = 300
+        max_examples = "5"
     else:
         path_regex = r"^/api/(auth|users|teams|seasons|training)/"
         timeout_sec = 300
-
-    # Reduzir complexidade para training (muitos endpoints) - usar max-examples=1
-    max_examples = "1" if module_filter == "training" else "5"
+        max_examples = "5"
 
     cmd = [
         st_cli, "run",

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -6247,14 +6247,17 @@ def _g11_http_runtime_contract(root: pathlib.Path) -> dict:
         path_regex = r"^/api/(auth|users|teams|seasons|training)/"
         timeout_sec = 300
 
+    # Reduzir complexidade para training (muitos endpoints) - usar max-examples menor
+    max_examples = "2" if module_filter == "training" else "5"
+
     cmd = [
         st_cli, "run",
         schema_url,
         "--url", staging_url.rstrip("/"),
         "--include-path-regex", path_regex,
         "--checks", "not_a_server_error,response_schema_conformance",
-        "--max-examples", "5",
-        "--request-timeout", "10",
+        "--max-examples", max_examples,
+        "--request-timeout", "30",
         "--no-color",
     ]
     try:


### PR DESCRIPTION
## Problema

Training module tem 36 endpoints e estava excedendo timeout de 300s mesmo com `max-examples=1`, causando falha no compliance test.

## Solução

Dividir training em 3 sub-grupos executados em paralelo na matrix do CI:

- **training-core**: mesocycles, microcycles, training-sessions (CRUD básico)
- **training-ops**: operations (archive, publish, start) + attendance + wellness
- **training-intelligence**: feedback, messages, recommendations, load-chart, suggestions

Cada sub-grupo: ~12 endpoints × 1 example = ~100-120s (< 300s limit).

## Mudanças

1. `.github/workflows/deploy.yml`: matrix com 7 jobs (era 5)
2. `scripts/contracts/validate/validate_contracts.py`: mapeamento de sub-grupos para path regexes

## Resultado Esperado

✅ Todos 7 compliance tests PASS:
- auth, users, teams, seasons (já passando)
- training-core, training-ops, training-intelligence (novos)