### PR TITLE
fix(deploy): create production directory before SCP transfer (#73)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -454,6 +454,15 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Criar diretório de produção no servidor
+        if: steps.check-prod.outputs.skip != 'true'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST_PRODUCTION }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: mkdir -p /opt/hbtrack/production
+
       - name: Sincronizar infra para o servidor produção
         if: steps.check-prod.outputs.skip != 'true'
         uses: appleboy/scp-action@v0.1.7

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-04-13"
-branch_ativo: fix/certbot-port-conflict
+branch_ativo: fix/production-mkdir
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training


### PR DESCRIPTION
## Summary
- Production deploy Job 7 failed at SCP step: `tar: infra: Cannot mkdir: Permission denied`
- `/opt/hbtrack/production` didn't exist on the VPS
- Added SSH step `mkdir -p /opt/hbtrack/production` before SCP transfer

## Root Cause
Deploy run [24679266513](https://github.com/hbtrack/official/actions/runs/24679266513) — Job 7 step 5 failed

## Test plan
- [ ] CI passes
- [ ] Deploy pipeline runs Job 7 successfully after merge