### PR TITLE
fix(deploy): ensure production directory is writable for SCP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -461,7 +461,9 @@ jobs:
           host: ${{ secrets.VPS_HOST_PRODUCTION }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          script: mkdir -p /opt/hbtrack/production
+          script: |
+            mkdir -p /opt/hbtrack/production
+            chmod 755 /opt/hbtrack/production
 
       - name: Sincronizar infra para o servidor produção
         if: steps.check-prod.outputs.skip != 'true'

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-04-13"
-branch_ativo: fix/production-mkdir
+branch_ativo: fix/production-scp-permissions
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training


### PR DESCRIPTION
## Summary
- Production SCP still failed with `Permission denied` after mkdir fix (#73)
- `mkdir -p` created the dir but with restricted permissions
- Added `chmod 755` to ensure drone-scp can extract files into it

## Test plan
- [ ] CI passes
- [ ] Deploy pipeline Job 7 SCP step succeeds