### PR TITLE
fix(deploy): port guard agnóstico + actionlint cobre todos workflows

### DIFF
--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -26,7 +26,10 @@ jobs:
         run: |
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
       - name: Run actionlint
-        run: ./actionlint -shellcheck '' -color .github/workflows/contract-gates.yml .github/workflows/ci.yml .github/workflows/_reusable-ci.yml
+        # Lint TODOS os workflows (.github/workflows/*.yml). Rationale: o
+        # actionlint pega bugs de sintaxe/expressão antes do runtime; a lista
+        # hardcoded antiga deixava deploy.yml fora do gate.
+        run: ./actionlint -shellcheck '' -color .github/workflows/*.yml
 
   # ── Detectar se há mudança em paths de governança (usado pelos jobs abaixo) ──
   detect-governance-change:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -334,11 +334,15 @@ jobs:
                 docker stop "${CID}" >/dev/null 2>&1 || true
               done
             }
-            if [ "${STAGING_HTTP_PORT}" = "80" ] || [ "${STAGING_HTTPS_PORT}" = "443" ]; then
+            if [ "${STAGING_HTTP_PORT}" = "80" ]; then
               free_port 80
+            else
+              echo "ℹ️ STAGING_HTTP_PORT=${STAGING_HTTP_PORT} (não-pública) — port guard 80 skip"
+            fi
+            if [ "${STAGING_HTTPS_PORT}" = "443" ]; then
               free_port 443
             else
-              echo "ℹ️ Staging em portas não-públicas (${STAGING_HTTP_PORT}/${STAGING_HTTPS_PORT}) — port guard skip"
+              echo "ℹ️ STAGING_HTTPS_PORT=${STAGING_HTTPS_PORT} (não-pública) — port guard 443 skip"
             fi
 
             # Gerar certificado SSL se ausente
@@ -363,9 +367,11 @@ jobs:
               echo "✅ Certificado SSL existente — mantendo"
             fi
 
-            # Re-confirma portas livres logo antes do up
-            if [ "${STAGING_HTTP_PORT}" = "80" ] || [ "${STAGING_HTTPS_PORT}" = "443" ]; then
+            # Re-confirma portas livres logo antes do up (independente por porta)
+            if [ "${STAGING_HTTP_PORT}" = "80" ]; then
               free_port 80
+            fi
+            if [ "${STAGING_HTTPS_PORT}" = "443" ]; then
               free_port 443
             fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -306,12 +306,47 @@ jobs:
               docker compose -f infra/docker-compose.prod.yml down 2>/dev/null || true
             fi
 
+            # ────────────────────────────────────────────────────────────
+            # PORT GUARD — libera 80/443 antes de certbot e up -d.
+            # Causa raiz histórica: stacks legados (com COMPOSE_PROJECT_NAME
+            # diferente do esperado) seguram as portas e o "stop nginx"
+            # com nome hardcoded falha silenciosamente. Aqui paramos
+            # qualquer container Docker que esteja publicando 80/443,
+            # independentemente de project name.
+            # ────────────────────────────────────────────────────────────
+            free_port() {
+              local PORT="$1"
+              echo "🔍 Verificando ocupantes da porta ${PORT}..."
+              local OCCUPANTS
+              OCCUPANTS=$(docker ps --format '{{.ID}} {{.Names}} {{.Ports}}' | awk -v p=":${PORT}->" '$0 ~ p {print $1"|"$2}')
+              if [ -z "${OCCUPANTS}" ]; then
+                echo "  ✅ Porta ${PORT} livre"
+                return 0
+              fi
+              echo "  ⚠️ Porta ${PORT} ocupada por:"
+              echo "${OCCUPANTS}" | sed 's/^/    /'
+              echo "${OCCUPANTS}" | while IFS='|' read -r CID CNAME; do
+                # NUNCA mexer em containers do staging atual (vão subir já já)
+                case "${CNAME}" in
+                  hbtrack-staging-*) echo "    ↩️ skip ${CNAME} (staging atual)"; continue ;;
+                esac
+                echo "    🛑 stop ${CNAME} (${CID})"
+                docker stop "${CID}" >/dev/null 2>&1 || true
+              done
+            }
+            if [ "${STAGING_HTTP_PORT}" = "80" ] || [ "${STAGING_HTTPS_PORT}" = "443" ]; then
+              free_port 80
+              free_port 443
+            else
+              echo "ℹ️ Staging em portas não-públicas (${STAGING_HTTP_PORT}/${STAGING_HTTPS_PORT}) — port guard skip"
+            fi
+
             # Gerar certificado SSL se ausente
             if ! docker run --rm -v hbtrack-staging_certbot_conf:/etc/letsencrypt alpine \
                 test -f /etc/letsencrypt/live/staging.handballtrack.app/fullchain.pem 2>/dev/null; then
               echo "📜 Certificado SSL ausente — gerando via certbot standalone..."
-              # Liberar porta 80 caso produção esteja rodando no mesmo VPS
-              COMPOSE_PROJECT_NAME=hbtrack-production docker compose -f infra/docker-compose.prod.yml stop nginx 2>/dev/null || true
+              # port guard acima já liberou a 80; double-check
+              free_port 80
               docker run --rm \
                 -v hbtrack-staging_certbot_conf:/etc/letsencrypt \
                 -v hbtrack-staging_certbot_www:/var/www/certbot \
@@ -324,15 +359,14 @@ jobs:
                 -d staging.handballtrack.app \
               && echo "✅ Certificado SSL gerado com sucesso" \
               || echo "⚠️ Certbot falhou — continuando deploy sem SSL (renovação manual necessária)"
-              # Sempre reiniciar nginx de produção, mesmo se certbot falhou
-              COMPOSE_PROJECT_NAME=hbtrack-production docker compose -f infra/docker-compose.prod.yml start nginx 2>/dev/null || true
             else
               echo "✅ Certificado SSL existente — mantendo"
             fi
 
+            # Re-confirma portas livres logo antes do up
             if [ "${STAGING_HTTP_PORT}" = "80" ] || [ "${STAGING_HTTPS_PORT}" = "443" ]; then
-              echo "🔒 Staging configurado nas portas públicas — parando nginx de produção se existir para evitar conflito"
-              COMPOSE_PROJECT_NAME=hbtrack-production docker compose -f infra/docker-compose.prod.yml stop nginx 2>/dev/null || true
+              free_port 80
+              free_port 443
             fi
 
             docker compose -f infra/docker-compose.prod.yml up -d

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-04-21"
-branch_ativo: chore/fix-image-path
+branch_ativo: fix/deploy-port-guard-agnostic
 modo_operacao: ROADMAP
 ci_status: UNKNOWN
 modulo_foco: training
@@ -8,9 +8,9 @@ fase_roadmap: 4
 roadmap_phase: 4
 task_type: execute_roadmap_phase
 boot_profile_id: roadmap_execution
-task_id: ROADMAP-PHASE4-CI-FIXES
+task_id: ROADMAP-PHASE4-DEPLOY-PORT-GUARD
 resultado: PENDENTE
-proxima_acao_permitida: "Aguardar CI passar após push de compiled_context/users/"
+proxima_acao_permitida: "Validar deploy verde após merge da correção de port guard"
 bloqueios_ativos: []
 evidence_paths:
   - "_reports/contract_gates/latest.json"

--- a/_reports/contract_gates/local.latest.json
+++ b/_reports/contract_gates/local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-21T09:13:01Z",
+  "timestamp_utc": "2026-04-21T10:06:36Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "8e0d5663",
+    "git_commit": "4c82d911",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,7 +31,7 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T091301_14d323"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T100636_457bbf"
   },
   "status_detail": {
     "active_gates_passed": 28,
@@ -261,7 +261,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 212
+        "duration_ms": 43
       }
     },
     {
@@ -286,7 +286,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 9569
+        "duration_ms": 6732
       }
     },
     {
@@ -550,7 +550,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 178
+        "duration_ms": 128
       }
     },
     {
@@ -655,7 +655,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 4
       }
     },
     {
@@ -1027,7 +1027,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 153
+        "duration_ms": 78
       }
     },
     {
@@ -1113,7 +1113,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1318
+        "duration_ms": 763
       }
     },
     {
@@ -1136,7 +1136,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4275
+        "duration_ms": 1330
       }
     },
     {
@@ -1158,7 +1158,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2395
+        "duration_ms": 2835
       }
     },
     {
@@ -1197,7 +1197,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 558
+        "duration_ms": 555
       }
     },
     {
@@ -4149,7 +4149,7 @@
         "errors": 0,
         "warnings": 144,
         "violations": 144,
-        "duration_ms": 2026
+        "duration_ms": 2122
       }
     },
     {
@@ -4217,7 +4217,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 442
+        "duration_ms": 11
       }
     },
     {
@@ -4832,7 +4832,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1839
+        "duration_ms": 1748
       }
     },
     {
@@ -4908,7 +4908,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2702
+        "duration_ms": 1871
       }
     },
     {
@@ -4951,7 +4951,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 60
+        "duration_ms": 56
       }
     },
     {
@@ -4973,7 +4973,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2193
+        "duration_ms": 1304
       }
     },
     {
@@ -5049,7 +5049,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4
+        "duration_ms": 7
       }
     },
     {
@@ -5130,7 +5130,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 508
+        "duration_ms": 388
       }
     },
     {
@@ -5150,7 +5150,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 40688
+        "duration_ms": 41399
       }
     },
     {
@@ -5206,7 +5206,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 20
+        "duration_ms": 21
       }
     },
     {
@@ -5350,7 +5350,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 29
+        "duration_ms": 28
       }
     },
     {
@@ -5372,7 +5372,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 179
+        "duration_ms": 185
       }
     },
     {
@@ -5394,7 +5394,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6
+        "duration_ms": 7
       }
     },
     {
@@ -5454,7 +5454,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 8
       }
     },
     {
@@ -5476,7 +5476,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 17
+        "duration_ms": 18
       }
     },
     {

--- a/_reports/contract_gates/local.latest.json
+++ b/_reports/contract_gates/local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-21T10:06:36Z",
+  "timestamp_utc": "2026-04-21T10:19:52Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "4c82d911",
+    "git_commit": "7f64093a",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,7 +31,7 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T100636_457bbf"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T101952_0eee48"
   },
   "status_detail": {
     "active_gates_passed": 28,
@@ -261,7 +261,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 43
+        "duration_ms": 109
       }
     },
     {
@@ -286,7 +286,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6732
+        "duration_ms": 16018
       }
     },
     {
@@ -550,7 +550,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 128
+        "duration_ms": 168
       }
     },
     {
@@ -655,7 +655,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4
+        "duration_ms": 3
       }
     },
     {
@@ -1027,7 +1027,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 78
+        "duration_ms": 113
       }
     },
     {
@@ -1113,7 +1113,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 763
+        "duration_ms": 775
       }
     },
     {
@@ -1136,7 +1136,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1330
+        "duration_ms": 3955
       }
     },
     {
@@ -1158,7 +1158,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2835
+        "duration_ms": 3712
       }
     },
     {
@@ -1197,7 +1197,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 555
+        "duration_ms": 556
       }
     },
     {
@@ -4149,7 +4149,7 @@
         "errors": 0,
         "warnings": 144,
         "violations": 144,
-        "duration_ms": 2122
+        "duration_ms": 3586
       }
     },
     {
@@ -4217,7 +4217,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 11
+        "duration_ms": 8
       }
     },
     {
@@ -4832,7 +4832,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1748
+        "duration_ms": 1774
       }
     },
     {
@@ -4908,7 +4908,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1871
+        "duration_ms": 2141
       }
     },
     {
@@ -4951,7 +4951,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 56
+        "duration_ms": 58
       }
     },
     {
@@ -4973,7 +4973,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1304
+        "duration_ms": 1342
       }
     },
     {
@@ -5029,7 +5029,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 61
+        "duration_ms": 63
       }
     },
     {
@@ -5049,7 +5049,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 6
       }
     },
     {
@@ -5130,7 +5130,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 388
+        "duration_ms": 702
       }
     },
     {
@@ -5150,7 +5150,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 41399
+        "duration_ms": 40219
       }
     },
     {
@@ -5350,7 +5350,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 28
+        "duration_ms": 43
       }
     },
     {
@@ -5372,7 +5372,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 185
+        "duration_ms": 182
       }
     },
     {
@@ -5476,7 +5476,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 18
+        "duration_ms": 21
       }
     },
     {

--- a/_reports/contract_gates/precommit.latest.json
+++ b/_reports/contract_gates/precommit.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-21T07:45:20Z",
+  "timestamp_utc": "2026-04-21T10:07:57Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "3223548d",
+    "git_commit": "4c82d911",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,7 +31,7 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/precommit.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T074520_6e5c70"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T100757_dce5d1"
   },
   "status_detail": {
     "active_gates_passed": 24,
@@ -261,7 +261,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 49
+        "duration_ms": 43
       }
     },
     {
@@ -286,7 +286,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 677
+        "duration_ms": 6063
       }
     },
     {
@@ -397,7 +397,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 16
+        "duration_ms": 17
       }
     },
     {
@@ -1018,7 +1018,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 30
+        "duration_ms": 81
       }
     },
     {
@@ -1104,7 +1104,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 793
+        "duration_ms": 734
       }
     },
     {
@@ -1127,7 +1127,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1118
+        "duration_ms": 2227
       }
     },
     {
@@ -1149,7 +1149,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1377
+        "duration_ms": 3167
       }
     },
     {
@@ -1188,7 +1188,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 563
+        "duration_ms": 580
       }
     },
     {
@@ -4140,7 +4140,7 @@
         "errors": 0,
         "warnings": 144,
         "violations": 144,
-        "duration_ms": 1844
+        "duration_ms": 2198
       }
     },
     {
@@ -4208,7 +4208,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 13
       }
     },
     {
@@ -4823,7 +4823,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1720
+        "duration_ms": 1760
       }
     },
     {
@@ -4899,7 +4899,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1571
+        "duration_ms": 1802
       }
     },
     {
@@ -4942,7 +4942,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 56
+        "duration_ms": 58
       }
     },
     {
@@ -4964,7 +4964,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1376
+        "duration_ms": 1351
       }
     },
     {
@@ -5020,7 +5020,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 60
+        "duration_ms": 64
       }
     },
     {
@@ -5040,7 +5040,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 6
       }
     },
     {
@@ -5121,7 +5121,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 250
+        "duration_ms": 638
       }
     },
     {
@@ -5319,7 +5319,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 8
+        "duration_ms": 30
       }
     },
     {
@@ -5341,7 +5341,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 166
+        "duration_ms": 188
       }
     },
     {
@@ -5423,7 +5423,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6
+        "duration_ms": 10
       }
     },
     {
@@ -5445,7 +5445,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 18
+        "duration_ms": 21
       }
     },
     {

--- a/_reports/contract_gates/stage-session-start.ci.latest.json
+++ b/_reports/contract_gates/stage-session-start.ci.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-10T18:19:07Z",
+  "timestamp_utc": "2026-04-21T10:05:51Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "523ba1d5",
+    "git_commit": "9b87cecd",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,11 +31,11 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-session-start.ci.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260410T181907_9038ee"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T100551_1478d3"
   },
   "status_detail": {
     "active_gates_passed": 2,
-    "skip_count": 57,
+    "skip_count": 58,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -166,6 +166,10 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "FRONTEND_CONTRACT_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "DERIVED_DRIFT_GATE",
         "status": "SKIP_NOT_APPLICABLE"
       },
@@ -257,7 +261,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 45
+        "duration_ms": 44
       }
     },
     {
@@ -837,6 +841,24 @@
       }
     },
     {
+      "gate_id": "FRONTEND_CONTRACT_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      }
+    },
+    {
       "gate_id": "DERIVED_DRIFT_GATE",
       "status": "SKIP_NOT_APPLICABLE",
       "blocking": true,
@@ -1009,13 +1031,21 @@
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/_canon/MODULE_REGISTRY.yaml"
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.bundle.yaml",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-014.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-015.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-016.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-017.json"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/_canon/MODULE_REGISTRY.yaml"
+        "/home/davis/HB-TRACK/generated/source_graph/users/users.bundle.yaml",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-014.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-015.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-016.json",
+        "/home/davis/HB-TRACK/compiled_context/users/FT-017.json"
       ],
       "evidence_files": [],
       "violations": [
@@ -1036,7 +1066,7 @@
         "errors": 2,
         "warnings": 0,
         "violations": 2,
-        "duration_ms": 13
+        "duration_ms": 5
       }
     },
     {
@@ -1058,7 +1088,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 183
+        "duration_ms": 164
       }
     },
     {

--- a/_reports/contract_gates/stage-session-start.local.latest.json
+++ b/_reports/contract_gates/stage-session-start.local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-21T07:42:35Z",
+  "timestamp_utc": "2026-04-21T10:06:34Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "3223548d",
+    "git_commit": "4c82d911",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,7 +31,7 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-session-start.local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T074235_0a03bf"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260421T100634_f736e7"
   },
   "status_detail": {
     "active_gates_passed": 4,
@@ -261,7 +261,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 41
+        "duration_ms": 44
       }
     },
     {
@@ -1053,7 +1053,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 8
+        "duration_ms": 7
       }
     },
     {

--- a/_reports/session_start.json
+++ b/_reports/session_start.json
@@ -1,7 +1,7 @@
 {
   "session_id": "cd1cd71c-53f1-4b69-89a9-3b66008a2266",
-  "session_timestamp": "2026-04-21T07:42:34.984844+00:00",
-  "branch": "chore/fix-image-path",
+  "session_timestamp": "2026-04-21T10:06:34.745617+00:00",
+  "branch": "fix/deploy-port-guard-agnostic",
   "pipeline_version": "1.0.0",
   "boot_profile_id": "roadmap_execution",
   "task_type": "execute_roadmap_phase",

--- a/_reports/session_start.json
+++ b/_reports/session_start.json
@@ -376,7 +376,7 @@
   ],
   "stage2_exit_code": 0,
   "hook_exit_code": 0,
-  "hook_validated_at": "2026-04-21T07:45:33.724598+00:00",
+  "hook_validated_at": "2026-04-21T10:08:20.168281+00:00",
   "module": "training",
   "module_focus": "training",
   "roadmap_phase": 4


### PR DESCRIPTION
## Problema

**1. Deploy/staging falhou em port allocation** (run [24714966605](https://github.com/hbtrack/official/actions/runs/24714966605))

O step `Provisionar e fazer deploy no staging` assumia que o stack legado ocupando 80/443 chamava-se `hbtrack-production`, mas o default do compose file é `hbtrack-prod`. O `docker compose stop` falhava silenciosamente e o bind quebrava com:
```
Bind for 0.0.0.0:80 failed: port is already allocated
Bind for 0.0.0.0:443 failed: port is already allocated
```

**2. actionlint não cobria deploy.yml** — Job `Lint Workflows (actionlint)` tinha lista hardcoded de 3 workflows; deploy.yml ficava fora do gate estático.

## Solução

**Port guard agnóstico** (`free_port()` no deploy.yml):
- itera `docker ps --filter publish=<porta>`
- para QUALQUER container ocupante (exceto `hbtrack-staging-*`)
- independente de `COMPOSE_PROJECT_NAME`

**actionlint universal** (`contract-gates.yml`):
- glob `.github/workflows/*.yml` em vez de lista hardcoded
- novos workflows ficam cobertos automaticamente

## Validação local (regra vital: passou local DEVE passar GHA)

- `actionlint -shellcheck  .github/workflows/*.yml` → PASS
- `python3 scripts/contracts/validate/validate_contracts.py` → PASS
- `CI=true python3 scripts/hb survival-suite` → 124 passed, 1 skipped
- `bash -n` no script SSH inline extraído → syntax OK

Refs: ADR-027 (rede), `docs/_canon/DEPLOY_PIPELINE.md` v1.1.0