### PR TITLE
fix: stabilize GHCR auth for VPS deploy pulls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -288,7 +288,8 @@ jobs:
               echo "✅ .env válido — credenciais existentes mantidas"
             fi
 
-            if ! echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin 2>&1; then
+            # Login no GHCR com credencial persistente para pull no VPS
+            if ! echo "${{ secrets.GHCR_PULL_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_PULL_USERNAME || github.actor }}" --password-stdin 2>&1; then
               echo "❌ Falha ao autenticar no GHCR"
               exit 1
             fi
@@ -599,8 +600,8 @@ jobs:
               echo "✅ .env válido"
             fi
 
-            # Autenticar no GHCR
-            if ! echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin 2>&1; then
+            # Login no GHCR com credencial persistente para pull no VPS
+            if ! echo "${{ secrets.GHCR_PULL_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_PULL_USERNAME || github.actor }}" --password-stdin 2>&1; then
               echo "❌ Falha ao autenticar no GHCR"
               exit 1
             fi


### PR DESCRIPTION
## Contexto
O deploy em staging falhou ao executar `docker compose pull` no VPS com `Error response from daemon: denied`.

A causa era o uso de credenciais efêmeras e dependentes do `github.actor` dentro do script SSH do workflow de deploy.

## O que muda
- usa `GHCR_PULL_TOKEN` como credencial persistente para pull no VPS
- usa `GHCR_PULL_USERNAME` como usuário explícito de login no GHCR
- mantém fallback para `GITHUB_TOKEN` e `github.actor` quando as secrets não estiverem definidas

## Operação
As secrets `GHCR_PULL_TOKEN` e `GHCR_PULL_USERNAME` já foram criadas no repositório.

## Validação
- `python3 scripts/contracts/validate/validate_contracts.py --profile precommit`