### PR TITLE
fix(ci): retry internal staging freshness check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -354,9 +354,7 @@ jobs:
 
             echo "Aguardando frontend interno responder com o build esperado..."
             for i in $(seq 1 24); do
-              HTML="$(docker compose -f infra/docker-compose.staging.yml exec -T frontend \
-                sh -lc 'wget -qO- "http://127.0.0.1/?deploy_sha='"${EXPECTED_SHA}"'" 2>/dev/null || true)"
-
+              HTML="$(docker compose -f infra/docker-compose.staging.yml exec -T -e EXPECTED_SHA="${EXPECTED_SHA}" frontend sh -lc 'wget -qO- "http://127.0.0.1/?deploy_sha=${EXPECTED_SHA}" 2>/dev/null || true')"
               if printf "%s" "$HTML" | grep -F "hb-build-sha" >/dev/null \
                 && printf "%s" "$HTML" | grep -F "${EXPECTED_SHA}" >/dev/null; then
                 echo "✅ Frontend interno serve o SHA esperado (tentativa $i)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -352,16 +352,27 @@ jobs:
             cd /opt/hbtrack/staging
             EXPECTED_SHA="${{ github.sha }}"
 
-            HTML="$(docker compose -f infra/docker-compose.staging.yml exec -T frontend \
-              wget -qO- "http://localhost/?deploy_sha=${EXPECTED_SHA}")"
-            if ! printf "%s" "$HTML" | grep -F "hb-build-sha" >/dev/null; then
-              echo "❌ HTML interno não contém meta hb-build-sha"
-              exit 1
-            fi
-            if ! printf "%s" "$HTML" | grep -F "${EXPECTED_SHA}" >/dev/null; then
-              echo "❌ HTML interno não contém o SHA esperado ${EXPECTED_SHA}"
-              exit 1
-            fi
+            echo "Aguardando frontend interno responder com o build esperado..."
+            for i in $(seq 1 24); do
+              HTML="$(docker compose -f infra/docker-compose.staging.yml exec -T frontend \
+                sh -lc 'wget -qO- "http://127.0.0.1/?deploy_sha='"${EXPECTED_SHA}"'" 2>/dev/null || true)"
+
+              if printf "%s" "$HTML" | grep -F "hb-build-sha" >/dev/null \
+                && printf "%s" "$HTML" | grep -F "${EXPECTED_SHA}" >/dev/null; then
+                echo "✅ Frontend interno serve o SHA esperado (tentativa $i)"
+                break
+              fi
+
+              if [ "$i" -eq 24 ]; then
+                echo "❌ Frontend interno não serviu o SHA esperado após 120s"
+                echo "--- HTML retornado (última tentativa) ---"
+                printf "%s\n" "$HTML"
+                exit 1
+              fi
+
+              echo "⏳ Tentativa $i/24 — frontend ainda não pronto"
+              sleep 5
+            done
 
             HEALTH="$(docker compose -f infra/docker-compose.staging.yml exec -T api \
               curl -sf --max-time 5 http://localhost:8000/health)"


### PR DESCRIPTION
## Resumo
Corrige a validação de freshness do staging para não falhar de forma prematura enquanto o frontend ainda está inicializando.

## Mudanças
- adiciona retry no freshness check interno do frontend
- troca localhost por 127.0.0.1 no probe interno do frontend
- preserva a validação do buildSha no /health da API

## Contexto
O deploy em staging estava passando no health check da API, mas falhando no freshness check do frontend com Connection refused antes de o frontend responder com o build esperado.
