### PR TITLE
feat(enforcement): RULE_CHANGE_QUARANTINE_GATE — Contenção 2 do HBCONTROL

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,46 +1,50 @@
 ---
 data_ultima_sessao: "2026-04-26"
-branch_ativo: fix/handoff-post-pr93-coherence
+branch_ativo: feat/rule-change-quarantine
 modo_operacao: CDD
 ci_status: PASS
 modulo_foco: notifications
 fase_roadmap: 1
 task_type: architecture_review
 boot_profile_id: architecture_decision
-task_id: GATES_REGISTRY_PREFLIGHT_INTEGRITY_GATE
+task_id: RULE_CHANGE_QUARANTINE_GATE
 resultado: DONE
-proxima_acao_permitida: "PR #93 mergeado (577cdc5c). Próxima tarefa: RULE_CHANGE_QUARANTINE (Contenção 2 do HBCONTROL.md) — impede modificações ad-hoc em scripts de enforcement durante merge flow ativo."
+proxima_acao_permitida: "RULE_CHANGE_QUARANTINE_GATE implementado (Contenção 2 do HBCONTROL.md). Próxima ação: abrir PR feat/rule-change-quarantine → main."
 bloqueios_ativos: []
 evidence_paths:
   - "_reports/contract_gates/latest.json"
   - "docs/_canon/gates/GATES_REGISTRY.yaml"
-  - "scripts/hb"
-  - "tests/pipeline/test_preflight_artifact_integrity.py"
+  - "scripts/contracts/validate/validate_contracts.py"
+  - "tests/pipeline/test_rule_change_quarantine.py"
 ---
-# SESSION HANDOFF — CDD Architecture Review
+# SESSION HANDOFF — RULE_CHANGE_QUARANTINE_GATE
 
 ## Estado Geral
-**Data:** 2026-04-26 | **Branch:** fix/handoff-post-pr93-coherence | **CI:** PASS
+**Data:** 2026-04-26 | **Branch:** feat/rule-change-quarantine | **CI:** PASS
 **Modo:** CDD | **task_type:** architecture_review | **boot_profile:** architecture_decision
-**Módulo foco:** notifications | **Fase ROADMAP:** 1 | **task_id:** GATES_REGISTRY_PREFLIGHT_INTEGRITY_GATE | **Resultado:** DONE
+**Módulo foco:** notifications | **Fase ROADMAP:** 1 | **task_id:** RULE_CHANGE_QUARANTINE_GATE | **Resultado:** DONE
 
 ## O que foi feito
-- ✅ Commit e758d2e2: PREFLIGHT_ARTIFACT_INTEGRITY_GATE implementado em scripts/hb (+203 linhas)
-- ✅ PR #93 criado: feat/preflight-artifact-integrity-gate → main
-- ✅ Achado do Gemini Review (CRITICAL): gate ausente do docs/_canon/gates/GATES_REGISTRY.yaml
-- ✅ Gate registrado em GATES_REGISTRY.yaml: entry 15I5, proof_class=semantic, promotion_power=blocking, integrated_in_validate_contracts=false
-- ✅ Codex P2 resolvido: report_target_mismatch retorna STALE (exit 0) em vez de FAIL
-- ✅ Todos os 14 checks do PR #93: success
-- ✅ Conversa inline Codex P2 resolvida via GraphQL
-- ✅ **PR #93 mergeado em main** — commit squash 577cdc5c
+- ✅ PR #93 mergeado (577cdc5c) — PREFLIGHT_ARTIFACT_INTEGRITY_GATE (Contenção 1)
+- ✅ PR #94 mergeado (d07fc801) — fix handoff coherence (SESSION_HANDOFF.md)
+- ✅ Branch feat/rule-change-quarantine criado a partir de main (d07fc801)
+- ✅ BLOCKED_RULE_CHANGE_QUARANTINE adicionado como constante de bloqueio
+- ✅ BLOCKED_RULE_CHANGE_QUARANTINE adicionado a _KNOWN_BLOCKING_CODES
+- ✅ _ENFORCEMENT_QUARANTINE_PREFIXES e _PRODUCT_ZONE_PREFIXES definidos
+- ✅ _classify_changed_file() helper implementado
+- ✅ _get_pr_changeset() helper implementado (3 estratégias: pr_diff, staged, last_commit)
+- ✅ _g_rule_change_quarantine() gate function implementada
+- ✅ Gate adicionado ao gate_plan em _run_pipeline()
+- ✅ RULE_CHANGE_QUARANTINE_GATE registrado em docs/_canon/gates/GATES_REGISTRY.yaml (order 20S)
+- ✅ 31 testes adversariais criados em tests/pipeline/test_rule_change_quarantine.py — todos passando
 
 ## Evidências
-- `docs/_canon/gates/GATES_REGISTRY.yaml` — entry 15I5 adicionado
-- `scripts/hb` — gate implementado + fix Codex P2
-- `tests/pipeline/test_preflight_artifact_integrity.py` — 9 testes adversariais
+- `scripts/contracts/validate/validate_contracts.py` — gate implementado
+- `docs/_canon/gates/GATES_REGISTRY.yaml` — entry RULE_CHANGE_QUARANTINE_GATE (20S)
+- `tests/pipeline/test_rule_change_quarantine.py` — 31 testes adversariais
 
 ## Próxima ação permitida
-PR #93 mergeado. Próxima tarefa: `RULE_CHANGE_QUARANTINE` (Contenção 2 do HBCONTROL.md) — impede modificações ad-hoc em scripts de enforcement durante merge flow ativo.
+Abrir PR feat/rule-change-quarantine → main.
 
 ## Bloqueios ativos
 Nenhum.

--- a/docs/_canon/gates/GATES_REGISTRY.yaml
+++ b/docs/_canon/gates/GATES_REGISTRY.yaml
@@ -1436,7 +1436,7 @@ gates:
     order: "20S"
     name: "Rule Change Quarantine Gate"
     blocking: true
-    active_stage: pre_check
+    active_stage: pre_contract
     severity: HIGH
     parallelizable: false
     applies_when: always

--- a/docs/_canon/gates/GATES_REGISTRY.yaml
+++ b/docs/_canon/gates/GATES_REGISTRY.yaml
@@ -1456,5 +1456,6 @@ gates:
       Obtém changeset via: (1) git diff origin/main...HEAD, (2) staging area,
       (3) último commit. SKIP_NOT_APPLICABLE se git não estiver disponível.
     blocking_codes: [ BLOCKED_RULE_CHANGE_QUARANTINE ]
+    skip_allowed_in_ci: true
     status: active
     implemented_in: scripts/contracts/validate/validate_contracts.py

--- a/docs/_canon/gates/GATES_REGISTRY.yaml
+++ b/docs/_canon/gates/GATES_REGISTRY.yaml
@@ -1431,3 +1431,30 @@ gates:
     status: active
     integrated_in_validate_contracts: false
     enhancement_notes: "Implementar lock.json em cada gerador (todos v0.1+). Gate será integrado no executor quando .lock.json for emitido pelos geradores (v0.2+)."
+
+  - gate_id: RULE_CHANGE_QUARANTINE_GATE
+    order: "20S"
+    name: "Rule Change Quarantine Gate"
+    blocking: true
+    active_stage: pre_check
+    severity: HIGH
+    parallelizable: false
+    applies_when: always
+    depends_on: [ GOVERNANCE_REGRESSION_GATE ]
+    description: >
+      Contenção 2 do HBCONTROL.md — impede que modificações em arquivos de
+      enforcement sejam misturadas com mudanças de produto no mesmo commit/PR.
+
+      Enforcement zone (quarantine): scripts/hb, scripts/contracts/validate/,
+      scripts/audit/, docs/_canon/gates/, merge-readiness.json,
+      .contract_driven/DOMAIN_AXIOMS.json, .contract_driven/TASK_CATALOG.yaml.
+
+      Product zone: src/, frontend/, migrations/, contracts/openapi/,
+      contracts/asyncapi/, contracts/schemas/.
+
+      FAIL se o changeset contiver arquivos de ambas as zonas simultaneamente.
+      Obtém changeset via: (1) git diff origin/main...HEAD, (2) staging area,
+      (3) último commit. SKIP_NOT_APPLICABLE se git não estiver disponível.
+    blocking_codes: [ BLOCKED_RULE_CHANGE_QUARANTINE ]
+    status: active
+    implemented_in: scripts/contracts/validate/validate_contracts.py

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -11020,8 +11020,16 @@ _PRODUCT_ZONE_PREFIXES: tuple[str, ...] = (
 def _classify_changed_file(rel_path: str) -> str:
     """Classifica um arquivo alterado em 'enforcement', 'product' ou 'other'."""
     for prefix in _ENFORCEMENT_QUARANTINE_PREFIXES:
-        if rel_path == prefix or rel_path.startswith(prefix):
-            return "enforcement"
+        # Para prefixos sem separador de diretório (ex: 'scripts/hb'), comparar
+        # estritamente como arquivo exato OU como prefixo de subdiretório
+        # (ex: 'scripts/hb/' com barra), evitando falsos positivos em
+        # caminhos como 'scripts/hbtrack_lint/' que começam com 'scripts/hb'.
+        if prefix.endswith("/"):
+            if rel_path == prefix.rstrip("/") or rel_path.startswith(prefix):
+                return "enforcement"
+        else:
+            if rel_path == prefix or rel_path.startswith(prefix + "/"):
+                return "enforcement"
     for prefix in _PRODUCT_ZONE_PREFIXES:
         if rel_path.startswith(prefix):
             return "product"
@@ -11033,14 +11041,20 @@ def _get_pr_changeset(root: pathlib.Path) -> tuple[list[str] | None, str]:
     Obtém a lista de arquivos alterados no changeset atual.
 
     Estratégias (em ordem de prioridade):
-    1. git diff --name-only origin/main...HEAD  (PR CI)
+    1. git diff --name-only <base>...HEAD  (PR CI — base resolvida dinamicamente
+       via GITHUB_BASE_REF env, com fallback para 'main')
     2. git diff --name-only --cached            (pre-commit)
     3. git diff --name-only HEAD~1..HEAD        (último commit)
 
     Retorna (lista de paths relativos, fonte_usada) ou (None, motivo_do_skip).
     """
+    # Resolver a branch base dinamicamente: GITHUB_BASE_REF é definido pelo
+    # runner de CI (ex: 'main', 'develop'); fallback para 'main' localmente.
+    import os as _os
+    base_branch = _os.environ.get("GITHUB_BASE_REF", "main").strip() or "main"
+    pr_diff_ref = f"origin/{base_branch}...HEAD"
     strategies: list[tuple[list[str], str]] = [
-        (["git", "diff", "--name-only", "origin/main...HEAD"], "pr_diff"),
+        (["git", "diff", "--name-only", pr_diff_ref], "pr_diff"),
         (["git", "diff", "--name-only", "--cached"], "staged"),
         (["git", "diff", "--name-only", "HEAD~1..HEAD"], "last_commit"),
     ]

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -117,6 +117,7 @@ BLOCKED_HOOK_EFFECTIVENESS = "BLOCKED_HOOK_EFFECTIVENESS"
 BLOCKED_REPORT_TRUTHFULNESS = "BLOCKED_REPORT_TRUTHFULNESS"
 BLOCKED_LIVE_ENFORCEMENT_PARITY = "BLOCKED_LIVE_ENFORCEMENT_PARITY"
 BLOCKED_MODULE_BEHAVIORAL_READINESS = "BLOCKED_MODULE_BEHAVIORAL_READINESS"
+BLOCKED_RULE_CHANGE_QUARANTINE = "BLOCKED_RULE_CHANGE_QUARANTINE"
 
 MODULE_STATUS_ORDER = (
     "scaffold",
@@ -219,6 +220,7 @@ _KNOWN_BLOCKING_CODES = {
     BLOCKED_REPORT_TRUTHFULNESS,
     BLOCKED_LIVE_ENFORCEMENT_PARITY,
     BLOCKED_MODULE_BEHAVIORAL_READINESS,
+    BLOCKED_RULE_CHANGE_QUARANTINE,
 }
 
 
@@ -10988,6 +10990,165 @@ def _g_hbtrack_canon_parity(root: pathlib.Path) -> dict:
                [], checked, [], [], _ms(t0))
 
 
+# ── Enforcement quarantine paths ─────────────────────────────────────────────
+# Arquivos cujas alterações definem o que é bloqueado/permitido no pipeline.
+# Modificações nestes caminhos devem ocorrer em PRs dedicados, isolados de
+# mudanças de produto.
+_ENFORCEMENT_QUARANTINE_PREFIXES: tuple[str, ...] = (
+    "scripts/hb",
+    "scripts/contracts/validate/",
+    "scripts/audit/",
+    "docs/_canon/gates/",
+    "merge-readiness.json",
+    ".contract_driven/DOMAIN_AXIOMS.json",
+    ".contract_driven/TASK_CATALOG.yaml",
+)
+
+# Caminhos de produto: código de aplicação, contratos API, frontend, migrations.
+# Modificações aqui representam entrega de produto — não devem ser misturadas
+# com alterações de enforcement no mesmo changeset.
+_PRODUCT_ZONE_PREFIXES: tuple[str, ...] = (
+    "src/",
+    "frontend/",
+    "migrations/",
+    "contracts/openapi/",
+    "contracts/asyncapi/",
+    "contracts/schemas/",
+)
+
+
+def _classify_changed_file(rel_path: str) -> str:
+    """Classifica um arquivo alterado em 'enforcement', 'product' ou 'other'."""
+    for prefix in _ENFORCEMENT_QUARANTINE_PREFIXES:
+        if rel_path == prefix or rel_path.startswith(prefix):
+            return "enforcement"
+    for prefix in _PRODUCT_ZONE_PREFIXES:
+        if rel_path.startswith(prefix):
+            return "product"
+    return "other"
+
+
+def _get_pr_changeset(root: pathlib.Path) -> tuple[list[str] | None, str]:
+    """
+    Obtém a lista de arquivos alterados no changeset atual.
+
+    Estratégias (em ordem de prioridade):
+    1. git diff --name-only origin/main...HEAD  (PR CI)
+    2. git diff --name-only --cached            (pre-commit)
+    3. git diff --name-only HEAD~1..HEAD        (último commit)
+
+    Retorna (lista de paths relativos, fonte_usada) ou (None, motivo_do_skip).
+    """
+    strategies: list[tuple[list[str], str]] = [
+        (["git", "diff", "--name-only", "origin/main...HEAD"], "pr_diff"),
+        (["git", "diff", "--name-only", "--cached"], "staged"),
+        (["git", "diff", "--name-only", "HEAD~1..HEAD"], "last_commit"),
+    ]
+    for cmd, label in strategies:
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, cwd=str(root), timeout=15,
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                continue
+            files = [f.strip() for f in result.stdout.strip().splitlines() if f.strip()]
+            if files:
+                return files, label
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            continue
+    return None, "git_unavailable_or_no_changeset"
+
+
+def _g_rule_change_quarantine(root: pathlib.Path) -> dict:
+    """RULE_CHANGE_QUARANTINE_GATE — Impede que modificações em arquivos de
+    enforcement sejam misturadas com mudanças de produto no mesmo commit/PR.
+
+    Contenção 2 do HBCONTROL.md: cada PR deve ser homogêneo — puramente de
+    enforcement OU puramente de produto. Mistura invalida o isolamento do
+    pipeline de governança.
+
+    Enforcement zone (quarantine):
+      scripts/hb, scripts/contracts/validate/, scripts/audit/,
+      docs/_canon/gates/, merge-readiness.json,
+      .contract_driven/DOMAIN_AXIOMS.json, .contract_driven/TASK_CATALOG.yaml
+
+    Product zone:
+      src/, frontend/, migrations/, contracts/openapi/,
+      contracts/asyncapi/, contracts/schemas/
+
+    FAIL se changeset contiver arquivos de ambas as zonas simultaneamente.
+    SKIP_NOT_APPLICABLE se changeset não puder ser determinado (git ausente).
+    """
+    t0 = time.monotonic()
+    gate_id = "RULE_CHANGE_QUARANTINE_GATE"
+
+    changed_files, source = _get_pr_changeset(root)
+    if changed_files is None:
+        return _skip(gate_id, f"Changeset indisponível ({source}) — gate não aplicável.", _ms(t0))
+
+    enforcement_files: list[str] = []
+    product_files: list[str] = []
+    for f in changed_files:
+        zone = _classify_changed_file(f)
+        if zone == "enforcement":
+            enforcement_files.append(f)
+        elif zone == "product":
+            product_files.append(f)
+
+    checked = ["(git changeset via " + source + ")"]
+
+    if enforcement_files and product_files:
+        violations = [
+            {
+                "blocking_code": BLOCKED_RULE_CHANGE_QUARANTINE,
+                "artifact": "git changeset",
+                "message": (
+                    "Changeset misto detectado: arquivos de enforcement e de produto "
+                    "no mesmo commit/PR. Separar em PRs distintos."
+                ),
+                "severity": "error",
+                "details": {
+                    "enforcement_files": sorted(enforcement_files),
+                    "product_files": sorted(product_files),
+                    "changeset_source": source,
+                },
+            }
+        ]
+        return _pg(
+            gate_id,
+            "FAIL",
+            True,
+            BLOCKED_RULE_CHANGE_QUARANTINE,
+            (
+                f"Changeset misto: {len(enforcement_files)} arquivo(s) de enforcement + "
+                f"{len(product_files)} arquivo(s) de produto no mesmo PR."
+            ),
+            [],
+            checked,
+            [],
+            violations,
+            _ms(t0),
+        )
+
+    zone_label = (
+        "enforcement-only"
+        if enforcement_files
+        else ("product-only" if product_files else "neutral")
+    )
+    return _pg(
+        gate_id,
+        "PASS",
+        True,
+        None,
+        f"Changeset homogêneo ({zone_label}): sem mistura de enforcement + produto.",
+        [],
+        checked,
+        [],
+        [],
+        _ms(t0),
+    )
+
+
 def _g16_readiness_summary(gates: list[dict], *, canonical_full_run: bool) -> dict:
     t0 = time.monotonic()
     gate_id = "READINESS_SUMMARY_GATE"
@@ -12119,6 +12280,7 @@ def run_pipeline(
         ("DOC_USAGE_GATE", lambda: _g_doc_usage(root)),
         ("CANON_CONTRACT_DRIVEN_PARITY_GATE", lambda: _g_canon_contract_driven_parity(root)),
         ("HBTRACK_CANON_PARITY_GATE", lambda: _g_hbtrack_canon_parity(root)),
+        ("RULE_CHANGE_QUARANTINE_GATE", lambda: _g_rule_change_quarantine(root)),
     ]
     for gate_id_hint, gate_fn in gate_plan:
         gate_result = _maybe(gate_fn, gate_id_hint)

--- a/tests/pipeline/test_rule_change_quarantine.py
+++ b/tests/pipeline/test_rule_change_quarantine.py
@@ -1,0 +1,225 @@
+"""Testes adversariais para RULE_CHANGE_QUARANTINE_GATE.
+
+Conteção 2 do HBCONTROL.md — impede que arquivos de enforcement sejam
+misturados com arquivos de produto no mesmo commit/PR.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import textwrap
+from unittest import mock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+VALIDATE_SCRIPT = REPO_ROOT / "scripts" / "contracts" / "validate" / "validate_contracts.py"
+
+
+def _load_validate_module():
+    module_name = "validate_contracts_rcq"
+    loader = importlib.machinery.SourceFileLoader(module_name, str(VALIDATE_SCRIPT))
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vc = _load_validate_module()
+
+_classify = vc._classify_changed_file
+_g_rule = vc._g_rule_change_quarantine
+_get_changeset = vc._get_pr_changeset
+
+
+# ── Testes de classificação de arquivos ──────────────────────────────────────
+
+class TestClassifyChangedFile:
+    def test_hb_script_is_enforcement(self):
+        assert _classify("scripts/hb") == "enforcement"
+
+    def test_validate_contracts_is_enforcement(self):
+        assert _classify("scripts/contracts/validate/validate_contracts.py") == "enforcement"
+
+    def test_audit_script_is_enforcement(self):
+        assert _classify("scripts/audit/check_architecture_docs.py") == "enforcement"
+
+    def test_gates_registry_is_enforcement(self):
+        assert _classify("docs/_canon/gates/GATES_REGISTRY.yaml") == "enforcement"
+
+    def test_merge_readiness_is_enforcement(self):
+        assert _classify("merge-readiness.json") == "enforcement"
+
+    def test_domain_axioms_is_enforcement(self):
+        assert _classify(".contract_driven/DOMAIN_AXIOMS.json") == "enforcement"
+
+    def test_task_catalog_is_enforcement(self):
+        assert _classify(".contract_driven/TASK_CATALOG.yaml") == "enforcement"
+
+    def test_src_is_product(self):
+        assert _classify("src/modules/training/api.py") == "product"
+
+    def test_frontend_is_product(self):
+        assert _classify("frontend/src/components/Roster.tsx") == "product"
+
+    def test_migrations_is_product(self):
+        assert _classify("migrations/0042_training_session.py") == "product"
+
+    def test_openapi_contracts_is_product(self):
+        assert _classify("contracts/openapi/paths/training.yaml") == "product"
+
+    def test_asyncapi_contracts_is_product(self):
+        assert _classify("contracts/asyncapi/events/training.yaml") == "product"
+
+    def test_json_schemas_is_product(self):
+        assert _classify("contracts/schemas/training/session.schema.json") == "product"
+
+    def test_session_handoff_is_other(self):
+        assert _classify("SESSION_HANDOFF.md") == "other"
+
+    def test_readme_is_other(self):
+        assert _classify("README.md") == "other"
+
+    def test_tests_is_other(self):
+        assert _classify("tests/pipeline/test_rule_change_quarantine.py") == "other"
+
+    def test_docs_canon_readme_is_other(self):
+        # docs/_canon/ que não seja gates/ é "other"
+        assert _classify("docs/_canon/CI_CONTRACT_GATES.md") == "other"
+
+    def test_gates_subdir_is_enforcement(self):
+        assert _classify("docs/_canon/gates/README.md") == "enforcement"
+
+
+# ── Testes do gate com git mockado ───────────────────────────────────────────
+
+class TestRuleChangeQuarantineGatePass:
+    """Gate deve retornar PASS para changesets homogêneos."""
+
+    def _run_with_files(self, files: list[str]) -> dict:
+        with mock.patch.object(vc, "_get_pr_changeset", return_value=(files, "pr_diff")):
+            return vc._g_rule_change_quarantine(REPO_ROOT)
+
+    def test_enforcement_only_passes(self):
+        result = self._run_with_files([
+            "scripts/contracts/validate/validate_contracts.py",
+            "docs/_canon/gates/GATES_REGISTRY.yaml",
+            "tests/pipeline/test_rule_change_quarantine.py",
+        ])
+        assert result["status"] == "PASS", result
+
+    def test_product_only_passes(self):
+        result = self._run_with_files([
+            "src/modules/training/api.py",
+            "contracts/openapi/paths/training.yaml",
+            "migrations/0042_add_session_field.py",
+        ])
+        assert result["status"] == "PASS", result
+
+    def test_neutral_only_passes(self):
+        result = self._run_with_files([
+            "SESSION_HANDOFF.md",
+            "README.md",
+            "ROADMAP.md",
+        ])
+        assert result["status"] == "PASS", result
+
+    def test_empty_changeset_passes(self):
+        result = self._run_with_files([])
+        assert result["status"] == "PASS", result
+
+    def test_enforcement_plus_neutral_passes(self):
+        """Enforcement + SESSION_HANDOFF.md deve ser PASS (sem produto)."""
+        result = self._run_with_files([
+            "scripts/hb",
+            "docs/_canon/gates/GATES_REGISTRY.yaml",
+            "SESSION_HANDOFF.md",
+            "tests/pipeline/test_rule_change_quarantine.py",
+        ])
+        assert result["status"] == "PASS", result
+
+
+class TestRuleChangeQuarantineGateFail:
+    """Gate deve retornar FAIL para changesets mistos (enforcement + produto)."""
+
+    def _run_with_files(self, files: list[str]) -> dict:
+        with mock.patch.object(vc, "_get_pr_changeset", return_value=(files, "pr_diff")):
+            return vc._g_rule_change_quarantine(REPO_ROOT)
+
+    def test_enforcement_plus_src_fails(self):
+        result = self._run_with_files([
+            "scripts/contracts/validate/validate_contracts.py",
+            "src/modules/training/api.py",
+        ])
+        assert result["status"] == "FAIL", result
+        assert result["blocking"] is True
+        assert result["blocking_code"] == "BLOCKED_RULE_CHANGE_QUARANTINE"
+
+    def test_hb_script_plus_openapi_fails(self):
+        result = self._run_with_files([
+            "scripts/hb",
+            "contracts/openapi/paths/training.yaml",
+        ])
+        assert result["status"] == "FAIL", result
+        assert result["blocking_code"] == "BLOCKED_RULE_CHANGE_QUARANTINE"
+
+    def test_gates_registry_plus_migrations_fails(self):
+        result = self._run_with_files([
+            "docs/_canon/gates/GATES_REGISTRY.yaml",
+            "migrations/0042_add_session_field.py",
+        ])
+        assert result["status"] == "FAIL", result
+
+    def test_merge_readiness_plus_frontend_fails(self):
+        result = self._run_with_files([
+            "merge-readiness.json",
+            "frontend/src/components/Dashboard.tsx",
+        ])
+        assert result["status"] == "FAIL", result
+
+    def test_violation_details_contain_both_lists(self):
+        """Violation details devem listar arquivos de enforcement e produto separadamente."""
+        result = self._run_with_files([
+            "scripts/hb",
+            "src/modules/training/api.py",
+            "SESSION_HANDOFF.md",  # este é "other", não deve aparecer em nenhuma lista
+        ])
+        assert result["status"] == "FAIL"
+        violation = result["violations"][0]
+        details = violation["details"]
+        assert "scripts/hb" in details["enforcement_files"]
+        assert "src/modules/training/api.py" in details["product_files"]
+        assert "SESSION_HANDOFF.md" not in details["enforcement_files"]
+        assert "SESSION_HANDOFF.md" not in details["product_files"]
+
+    def test_task_catalog_plus_json_schema_fails(self):
+        result = self._run_with_files([
+            ".contract_driven/TASK_CATALOG.yaml",
+            "contracts/schemas/training/session.schema.json",
+        ])
+        assert result["status"] == "FAIL", result
+
+
+class TestRuleChangeQuarantineGateSkip:
+    """Gate deve SKIP quando changeset não pode ser determinado."""
+
+    def test_skip_when_git_unavailable(self):
+        with mock.patch.object(
+            vc, "_get_pr_changeset", return_value=(None, "git_unavailable_or_no_changeset")
+        ):
+            result = vc._g_rule_change_quarantine(REPO_ROOT)
+        assert result["status"] == "SKIP_NOT_APPLICABLE", result
+
+
+class TestRuleChangeQuarantineGateLive:
+    """Testes contra o repositório real (PR atual)."""
+
+    def test_current_pr_is_enforcement_only(self):
+        """O PR atual (feat/rule-change-quarantine) deve ser enforcement-only ou neutral."""
+        result = vc._g_rule_change_quarantine(REPO_ROOT)
+        # Aceitar PASS ou SKIP (em caso de git indisponível ou sem origin/main)
+        assert result["status"] in ("PASS", "SKIP_NOT_APPLICABLE"), (
+            f"Gate falhou no PR atual — changeset misto detectado: {result}"
+        )

--- a/tests/pipeline/test_rule_change_quarantine.py
+++ b/tests/pipeline/test_rule_change_quarantine.py
@@ -58,6 +58,14 @@ class TestClassifyChangedFile:
     def test_task_catalog_is_enforcement(self):
         assert _classify(".contract_driven/TASK_CATALOG.yaml") == "enforcement"
 
+    def test_hbtrack_lint_is_other_not_enforcement(self):
+        """scripts/hbtrack_lint/ não deve ser classificado como enforcement (P2 fix)."""
+        assert _classify("scripts/hbtrack_lint/__init__.py") == "other"
+        assert _classify("scripts/hbtrack_lint/rules.py") == "other"
+
+    def test_hb_subfile_is_enforcement(self):
+        """scripts/hb/utils.py (hipotético) deve ser enforcement se estiver sob scripts/hb/."""
+        assert _classify("scripts/hb") == "enforcement"  # arquivo exato
     def test_src_is_product(self):
         assert _classify("src/modules/training/api.py") == "product"
 
@@ -223,3 +231,48 @@ class TestRuleChangeQuarantineGateLive:
         assert result["status"] in ("PASS", "SKIP_NOT_APPLICABLE"), (
             f"Gate falhou no PR atual — changeset misto detectado: {result}"
         )
+
+
+class TestGetPrChangesetBaseBranch:
+    """Testes da resolução dinâmica do base branch (P1 fix)."""
+
+    def test_uses_github_base_ref_env_when_set(self):
+        """Com GITHUB_BASE_REF=develop, deve usar origin/develop...HEAD."""
+        captured = {}
+
+        def mock_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            r = mock.MagicMock()
+            r.returncode = 0
+            r.stdout = "src/modules/training/api.py\n"
+            return r
+
+        with mock.patch("subprocess.run", side_effect=mock_run), \
+             mock.patch.dict("os.environ", {"GITHUB_BASE_REF": "develop"}):
+            vc._get_pr_changeset(REPO_ROOT)
+
+        assert captured["cmd"] == ["git", "diff", "--name-only", "origin/develop...HEAD"]
+
+    def test_defaults_to_main_when_no_env(self):
+        """Sem GITHUB_BASE_REF, deve usar origin/main...HEAD."""
+        captured = {}
+
+        def mock_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            r = mock.MagicMock()
+            r.returncode = 0
+            r.stdout = "src/modules/training/api.py\n"
+            return r
+
+        with mock.patch("subprocess.run", side_effect=mock_run), \
+             mock.patch.dict("os.environ", {}, clear=False):
+            env_backup = mock.patch.dict("os.environ")
+            env_backup.start()
+            import os
+            os.environ.pop("GITHUB_BASE_REF", None)
+            try:
+                vc._get_pr_changeset(REPO_ROOT)
+            finally:
+                env_backup.stop()
+
+        assert captured["cmd"] == ["git", "diff", "--name-only", "origin/main...HEAD"]


### PR DESCRIPTION
## Resumo

Implementa a **Contenção 2 do HBCONTROL.md**: gate que impede modificações em arquivos de enforcement misturadas com mudanças de produto no mesmo PR.

## Problema

Sem esse gate, é possível (e perigoso) incluir em um único PR:
- Alterações em `scripts/hb`, `validate_contracts.py` ou `docs/_canon/gates/` (enforcement)
- Junto com mudanças em `src/`, `frontend/`, `migrations/` ou contratos OpenAPI (produto)

Isso torna os gates auditáveis mas não verificáveis — o comportamento do enforcement muda junto com o produto, impedindo bisect limpo.

## Implementação

### `scripts/contracts/validate/validate_contracts.py`
- `_ENFORCEMENT_QUARANTINE_PREFIXES` — caminhos protegidos
- `_PRODUCT_ZONE_PREFIXES` — caminhos de produto
- `_classify_changed_file()` — classifica em `enforcement` | `product` | `other`
- `_get_pr_changeset()` — 3 estratégias: `pr_diff` > `staged` > `last_commit`
- `_g_rule_change_quarantine()` — gate com `BLOCKED_RULE_CHANGE_QUARANTINE`
- Gate adicionado ao `gate_plan` em `_run_pipeline()`

### `docs/_canon/gates/GATES_REGISTRY.yaml`
- Nova entrada `RULE_CHANGE_QUARANTINE_GATE` (order `20S`, blocking, severity HIGH)

### `tests/pipeline/test_rule_change_quarantine.py`
- 31 testes adversariais: `TestClassifyChangedFile`, `TestRuleChangeQuarantineGate{Pass,Fail,Skip,Live}`
- Todos passando localmente

## Auto-aplicação

Este PR é enforcement-only (sem arquivos de produto) — passa o próprio gate que introduz.

## CI Local
```
python3 scripts/hb validate --profile ci → PASS
pytest tests/pipeline/test_rule_change_quarantine.py → 31/31 passed
```

## Gate ID
`RULE_CHANGE_QUARANTINE_GATE` — order `20S` em `GATES_REGISTRY.yaml`

**Closes Contenção 2 do HBCONTROL.md**