### PR TITLE
chore(reports): regenerar artefatos canônicos pós-merge PR #95

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -20,7 +20,7 @@ evidence_paths:
 # SESSION HANDOFF — RULE_CHANGE_QUARANTINE_GATE
 
 ## Estado Geral
-**Data:** 2026-04-26 | **Branch:** main | **CI:** PASS
+**Data:** 2026-04-26 | **Branch:** chore/post-merge-report-95 | **CI:** PASS
 **Modo:** CDD | **task_type:** architecture_review | **boot_profile:** architecture_decision
 **Módulo foco:** notifications | **Fase ROADMAP:** 1 | **task_id:** RULE_CHANGE_QUARANTINE_GATE | **Resultado:** DONE
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 data_ultima_sessao: "2026-04-26"
-branch_ativo: feat/rule-change-quarantine
+branch_ativo: chore/post-merge-report-95
 modo_operacao: CDD
 ci_status: PASS
 modulo_foco: notifications
@@ -9,7 +9,7 @@ task_type: architecture_review
 boot_profile_id: architecture_decision
 task_id: RULE_CHANGE_QUARANTINE_GATE
 resultado: DONE
-proxima_acao_permitida: "RULE_CHANGE_QUARANTINE_GATE implementado (Contenção 2 do HBCONTROL.md). Próxima ação: abrir PR feat/rule-change-quarantine → main."
+proxima_acao_permitida: "PR #95 mergeado (12e9053f). Relatórios regenerados (69 gates, RULE_CHANGE_QUARANTINE_GATE=PASS). Pronto para merge do PR de relatório ou próxima tarefa."
 bloqueios_ativos: []
 evidence_paths:
   - "_reports/contract_gates/latest.json"
@@ -20,31 +20,27 @@ evidence_paths:
 # SESSION HANDOFF — RULE_CHANGE_QUARANTINE_GATE
 
 ## Estado Geral
-**Data:** 2026-04-26 | **Branch:** feat/rule-change-quarantine | **CI:** PASS
+**Data:** 2026-04-26 | **Branch:** main | **CI:** PASS
 **Modo:** CDD | **task_type:** architecture_review | **boot_profile:** architecture_decision
 **Módulo foco:** notifications | **Fase ROADMAP:** 1 | **task_id:** RULE_CHANGE_QUARANTINE_GATE | **Resultado:** DONE
 
 ## O que foi feito
 - ✅ PR #93 mergeado (577cdc5c) — PREFLIGHT_ARTIFACT_INTEGRITY_GATE (Contenção 1)
 - ✅ PR #94 mergeado (d07fc801) — fix handoff coherence (SESSION_HANDOFF.md)
-- ✅ Branch feat/rule-change-quarantine criado a partir de main (d07fc801)
-- ✅ BLOCKED_RULE_CHANGE_QUARANTINE adicionado como constante de bloqueio
-- ✅ BLOCKED_RULE_CHANGE_QUARANTINE adicionado a _KNOWN_BLOCKING_CODES
-- ✅ _ENFORCEMENT_QUARANTINE_PREFIXES e _PRODUCT_ZONE_PREFIXES definidos
-- ✅ _classify_changed_file() helper implementado
-- ✅ _get_pr_changeset() helper implementado (3 estratégias: pr_diff, staged, last_commit)
-- ✅ _g_rule_change_quarantine() gate function implementada
-- ✅ Gate adicionado ao gate_plan em _run_pipeline()
-- ✅ RULE_CHANGE_QUARANTINE_GATE registrado em docs/_canon/gates/GATES_REGISTRY.yaml (order 20S)
-- ✅ 31 testes adversariais criados em tests/pipeline/test_rule_change_quarantine.py — todos passando
+- ✅ PR #95 mergeado (12e9053f) — RULE_CHANGE_QUARANTINE_GATE (Contenção 2)
+  - `_classify_changed_file()` com boundary check (evita falso positivo scripts/hbtrack_lint/)
+  - `_get_pr_changeset()` com base branch dinâmico via GITHUB_BASE_REF env
+  - `active_stage: pre_contract` no GATES_REGISTRY.yaml
+  - 35 testes adversariais em tests/pipeline/test_rule_change_quarantine.py
+  - 14/14 checks CI passando | 5 threads de review resolvidas
 
 ## Evidências
-- `scripts/contracts/validate/validate_contracts.py` — gate implementado
-- `docs/_canon/gates/GATES_REGISTRY.yaml` — entry RULE_CHANGE_QUARANTINE_GATE (20S)
-- `tests/pipeline/test_rule_change_quarantine.py` — 31 testes adversariais
+- `scripts/contracts/validate/validate_contracts.py` — gate implementado + fixes de review
+- `docs/_canon/gates/GATES_REGISTRY.yaml` — entry RULE_CHANGE_QUARANTINE_GATE (order 20S)
+- `tests/pipeline/test_rule_change_quarantine.py` — 35 testes adversariais
 
 ## Próxima ação permitida
-Abrir PR feat/rule-change-quarantine → main.
+Main limpa em 12e9053f. Contenções 1 e 2 do HBCONTROL.md implementadas e mergeadas.
 
 ## Bloqueios ativos
 Nenhum.

--- a/_reports/READINESS_DASHBOARD.md
+++ b/_reports/READINESS_DASHBOARD.md
@@ -1,5 +1,5 @@
 # Dashboard de Readiness - HB Track
-> Gerado em 2026-04-25T10:43:12Z | run_id: `20260425T104312_9a1adb` | health: **100/100** | overall: **PASS**
+> Gerado em 2026-04-27T05:45:40Z | run_id: `20260427T054540_a57dda` | health: **100/100** | overall: **PASS**
 
 ## Modulos
 
@@ -93,5 +93,6 @@
 | DOC_USAGE_GATE | PASS | sim |
 | CANON_CONTRACT_DRIVEN_PARITY_GATE | PASS | sim |
 | HBTRACK_CANON_PARITY_GATE | PASS | sim |
+| RULE_CHANGE_QUARANTINE_GATE | PASS | sim |
 | REPORT_TRUTHFULNESS_GATE | PASS | sim |
 | READINESS_SUMMARY_GATE | PASS | nao |

--- a/_reports/contract_gates/latest.json
+++ b/_reports/contract_gates/latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-27T00:34:19Z",
+  "timestamp_utc": "2026-04-27T05:45:40Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "bd5b20ae",
+    "git_commit": "12e9053f",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,12 +31,12 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260427T003419_40c59c"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260427T054540_a57dda"
   },
   "status_detail": {
     "proof_scope": "factual",
-    "active_gates_total": 63,
-    "active_gates_passed": 63,
+    "active_gates_total": 64,
+    "active_gates_passed": 64,
     "skip_count": 5,
     "critical_gates": [
       {
@@ -260,6 +260,10 @@
         "status": "PASS"
       },
       {
+        "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+        "status": "PASS"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
@@ -289,7 +293,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 55
+        "duration_ms": 62
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -323,7 +327,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 547
+        "duration_ms": 11182
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -537,7 +541,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 10
+        "duration_ms": 40
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -676,7 +680,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 126
+        "duration_ms": 298
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -742,7 +746,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 25
       },
       "proof_class": "semantic",
       "promotion_power": "advisory",
@@ -772,7 +776,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 41
+        "duration_ms": 49
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -802,7 +806,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 36
+        "duration_ms": 39
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -832,7 +836,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 16
+        "duration_ms": 19
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -862,7 +866,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 95
+        "duration_ms": 142
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -892,7 +896,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 50
+        "duration_ms": 80
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -922,7 +926,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 45
+        "duration_ms": 58
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -952,7 +956,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 313
+        "duration_ms": 614
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -982,7 +986,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 30
+        "duration_ms": 62
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1048,7 +1052,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 24
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1121,7 +1125,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 30
+        "duration_ms": 259
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1157,7 +1161,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 113
+        "duration_ms": 137
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1272,7 +1276,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 5
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1654,7 +1658,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 28
+        "duration_ms": 102
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1749,7 +1753,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 886
+        "duration_ms": 836
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1781,7 +1785,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 977
+        "duration_ms": 4143
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1812,7 +1816,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1146
+        "duration_ms": 2453
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1860,7 +1864,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 537
+        "duration_ms": 658
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -4821,7 +4825,7 @@
         "errors": 0,
         "warnings": 144,
         "violations": 144,
-        "duration_ms": 1777
+        "duration_ms": 3472
       },
       "proof_class": "remote_live",
       "promotion_power": "blocking",
@@ -4898,7 +4902,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 5
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5524,7 +5528,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1685
+        "duration_ms": 2349
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5557,7 +5561,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1627
+        "duration_ms": 2894
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5586,7 +5590,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 4
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5644,7 +5648,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1366
+        "duration_ms": 2626
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5696,7 +5700,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 56
+        "duration_ms": 95
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5727,7 +5731,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1240
+        "duration_ms": 3123
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5792,7 +5796,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 58
+        "duration_ms": 85
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5821,7 +5825,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 5
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5911,7 +5915,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 180
+        "duration_ms": 984
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -5940,7 +5944,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 40247
+        "duration_ms": 49761
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5985,7 +5989,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 8
+        "duration_ms": 24
       },
       "proof_class": "behavioral",
       "promotion_power": "advisory",
@@ -6014,7 +6018,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 20
+        "duration_ms": 36
       },
       "proof_class": "presence",
       "promotion_power": "advisory",
@@ -6045,7 +6049,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 1
       },
       "proof_class": "semantic",
       "promotion_power": "advisory",
@@ -6119,7 +6123,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 12
       },
       "proof_class": "presence",
       "promotion_power": "none",
@@ -6242,7 +6246,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 70
+        "duration_ms": 380
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6274,7 +6278,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 7
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6309,7 +6313,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 418
+        "duration_ms": 896
       },
       "proof_class": "remote_live",
       "promotion_power": "blocking",
@@ -6333,16 +6337,16 @@
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
         "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
-        "/home/davis/HB-TRACK/scripts/hb",
-        "/home/davis/HB-TRACK/tests/pipeline/test_preflight_artifact_integrity.py"
+        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
+        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
         "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
-        "/home/davis/HB-TRACK/scripts/hb",
-        "/home/davis/HB-TRACK/tests/pipeline/test_preflight_artifact_integrity.py"
+        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
+        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
       ],
       "evidence_files": [],
       "violations": [],
@@ -6350,7 +6354,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 5
+        "duration_ms": 50
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6381,7 +6385,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 159
+        "duration_ms": 315
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6412,7 +6416,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6
+        "duration_ms": 9
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6514,7 +6518,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 77
+        "duration_ms": 304
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -6545,7 +6549,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 24
+        "duration_ms": 44
       },
       "proof_class": "semantic",
       "promotion_power": "advisory",
@@ -6919,7 +6923,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 930
+        "duration_ms": 1183
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6953,7 +6957,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 11
+        "duration_ms": 17
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6984,7 +6988,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 16
+        "duration_ms": 18
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -7011,7 +7015,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6
+        "duration_ms": 7
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -7041,7 +7045,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 27
+        "duration_ms": 30
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -7073,7 +7077,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 8
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -7103,7 +7107,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 30
+        "duration_ms": 60
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -7182,7 +7186,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 23
+        "duration_ms": 48
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -7211,7 +7215,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 3
       },
       "proof_class": "semantic",
       "promotion_power": "advisory",
@@ -7273,7 +7277,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 5393
+        "duration_ms": 6753
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -7300,7 +7304,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 18
       },
       "proof_class": "runtime",
       "promotion_power": "blocking",
@@ -7362,7 +7366,7 @@
         "errors": 1,
         "warnings": 0,
         "violations": 1,
-        "duration_ms": 34
+        "duration_ms": 39
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -7393,7 +7397,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 47
+        "duration_ms": 50
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -7424,7 +7428,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 8
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -7433,6 +7437,35 @@
       "stage_only": false,
       "skip_allowed_in_ci": false,
       "skip_allowed": false,
+      "applicability": "applicable",
+      "applicability_reason": "always"
+    },
+    {
+      "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+      "status": "PASS",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Changeset homogêneo (enforcement-only): sem mistura de enforcement + produto.",
+      "inputs": [],
+      "artifacts_checked": [
+        "(git changeset via last_commit)"
+      ],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 30
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
       "applicability": "applicable",
       "applicability_reason": "always"
     },
@@ -7471,7 +7504,7 @@
       "blocking": false,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Resumo de gates: 62 PASS, 5 SKIP.",
+      "summary": "Resumo de gates: 63 PASS, 5 SKIP.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/contract_gates/precommit.latest.json
+++ b/_reports/contract_gates/precommit.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-25T13:12:08Z",
+  "timestamp_utc": "2026-04-27T02:01:10Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "8742cec4",
+    "git_commit": "315cb044",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,13 +31,13 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/precommit.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260425T131208_4ee335"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260427T020110_b19b3d"
   },
   "status_detail": {
     "proof_scope": "mixed",
     "active_gates_total": 29,
     "active_gates_passed": 29,
-    "skip_count": 39,
+    "skip_count": 40,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -260,6 +260,10 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
@@ -382,7 +386,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 43
+        "duration_ms": 41
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -416,7 +420,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 476
+        "duration_ms": 3887
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -581,7 +585,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 14
+        "duration_ms": 15
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -1294,7 +1298,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 29
+        "duration_ms": 36
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1389,7 +1393,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 736
+        "duration_ms": 728
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1421,7 +1425,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1091
+        "duration_ms": 1024
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1452,7 +1456,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1234
+        "duration_ms": 1312
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1500,7 +1504,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 609
+        "duration_ms": 560
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -4461,7 +4465,7 @@
         "errors": 0,
         "warnings": 144,
         "violations": 144,
-        "duration_ms": 2017
+        "duration_ms": 1916
       },
       "proof_class": "remote_live",
       "promotion_power": "blocking",
@@ -4538,7 +4542,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 2
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5164,7 +5168,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1788
+        "duration_ms": 1799
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5276,7 +5280,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1556
+        "duration_ms": 1618
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5328,7 +5332,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 63
+        "duration_ms": 59
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5359,7 +5363,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1358
+        "duration_ms": 1390
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5424,7 +5428,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 69
+        "duration_ms": 60
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5453,7 +5457,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 3
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5543,7 +5547,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 243
+        "duration_ms": 294
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -5817,7 +5821,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 92
+        "duration_ms": 72
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5899,13 +5903,17 @@
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/contracts/openapi/paths/notifications.yaml"
+        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
+        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
+        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/contracts/openapi/paths/notifications.yaml"
+        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
+        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
+        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
       ],
       "evidence_files": [],
       "violations": [],
@@ -5913,7 +5921,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 5
+        "duration_ms": 4
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5944,7 +5952,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 182
+        "duration_ms": 162
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5975,7 +5983,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 6
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6077,7 +6085,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 89
+        "duration_ms": 108
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -6165,7 +6173,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 13
+        "duration_ms": 12
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6196,7 +6204,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 19
+        "duration_ms": 44
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -6223,7 +6231,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 7
+        "duration_ms": 8
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -6383,7 +6391,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 26
+        "duration_ms": 31
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6585,6 +6593,33 @@
       "applicability_reason": "Pulado no perfil 'precommit'."
     },
     {
+      "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no perfil 'precommit'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no perfil 'precommit'."
+    },
+    {
       "gate_id": "REPORT_TRUTHFULNESS_GATE",
       "status": "PASS",
       "blocking": true,
@@ -6619,7 +6654,7 @@
       "blocking": false,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Resumo de gates: 28 PASS, 39 SKIP.",
+      "summary": "Resumo de gates: 28 PASS, 40 SKIP.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/contract_gates/stage-session-start.local.latest.json
+++ b/_reports/contract_gates/stage-session-start.local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-25T13:12:06Z",
+  "timestamp_utc": "2026-04-27T02:01:08Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "8742cec4",
+    "git_commit": "315cb044",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,13 +31,13 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-session-start.local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260425T131206_35f9b0"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260427T020108_a2f173"
   },
   "status_detail": {
     "proof_scope": "mixed",
     "active_gates_total": 5,
     "active_gates_passed": 3,
-    "skip_count": 63,
+    "skip_count": 64,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -260,6 +260,10 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
@@ -478,7 +482,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 42
+        "duration_ms": 44
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1716,13 +1720,17 @@
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/contracts/openapi/paths/notifications.yaml"
+        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
+        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
+        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/contracts/openapi/paths/notifications.yaml"
+        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
+        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
+        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
       ],
       "evidence_files": [],
       "violations": [
@@ -1780,7 +1788,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 170
+        "duration_ms": 169
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -2275,6 +2283,33 @@
       "stage_only": false,
       "skip_allowed_in_ci": false,
       "skip_allowed": false,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
+      "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
       "applicability": "not_applicable",
       "applicability_reason": "Pulado no estágio 'session-start'."
     },

--- a/_reports/evidence/module_readiness_scorecard.json
+++ b/_reports/evidence/module_readiness_scorecard.json
@@ -1,6 +1,6 @@
 {
   "artifact_id": "HBTRACK_MODULE_READINESS_SCORECARD",
-  "generated_at_utc": "2026-04-25T10:43:12Z",
+  "generated_at_utc": "2026-04-27T05:45:40Z",
   "overall_status": "PASS",
   "source_report": "_reports/contract_gates/latest.json",
   "modules": [

--- a/_reports/evidence/module_readiness_scorecard.md
+++ b/_reports/evidence/module_readiness_scorecard.md
@@ -1,6 +1,6 @@
 # MODULE READINESS SCORECARD
 
-- Generated at: `2026-04-25T10:43:12Z`
+- Generated at: `2026-04-27T05:45:40Z`
 - Pipeline status: `PASS`
 
 | Module | Registry | Owner | Structural % | Behavioral % | Promotion | OpenAPI | Schemas | Missing / Drift |

--- a/_reports/pipeline_health.json
+++ b/_reports/pipeline_health.json
@@ -1,9 +1,9 @@
 {
-  "run_id": "20260425T104312_9a1adb",
-  "timestamp_utc": "2026-04-25T10:43:12Z",
+  "run_id": "20260427T054540_a57dda",
+  "timestamp_utc": "2026-04-27T05:45:40Z",
   "health_score": 100,
-  "gates_total": 68,
-  "gates_passed": 63,
+  "gates_total": 69,
+  "gates_passed": 64,
   "gates_failed": 0,
   "gates_skipped_optional": 5,
   "mandatory_ci_skip_count": 0,
@@ -30,16 +30,16 @@
     },
     "factual": {
       "score": 100,
-      "relevant": 53,
-      "passed": 53,
+      "relevant": 54,
+      "passed": 54,
       "failed": 0,
       "mandatory_skips": 0,
       "optional_skips": 4
     },
     "global": {
       "score": 100,
-      "relevant": 63,
-      "passed": 63,
+      "relevant": 64,
+      "passed": 64,
       "failed": 0,
       "mandatory_skips": 0,
       "optional_skips": 5

--- a/_reports/pipeline_history.jsonl
+++ b/_reports/pipeline_history.jsonl
@@ -1671,3 +1671,12 @@
 {"run_id": "20260425T101239_c00cdb", "timestamp_utc": "2026-04-25T10:12:39Z", "overall_status": "PASS", "exit_code": 0, "health_score": 100, "git_commit": "097ad464"}
 {"run_id": "20260425T104142_45bfe3", "timestamp_utc": "2026-04-25T10:41:42Z", "overall_status": "FAIL", "exit_code": 2, "health_score": 90, "git_commit": "d250b1d6"}
 {"run_id": "20260425T104312_9a1adb", "timestamp_utc": "2026-04-25T10:43:12Z", "overall_status": "PASS", "exit_code": 0, "health_score": 100, "git_commit": "d250b1d6"}
+{"run_id": "20260427T010747_63d5c5", "timestamp_utc": "2026-04-27T01:07:47Z", "overall_status": "FAIL", "exit_code": 2, "health_score": 90, "git_commit": "d07fc801"}
+{"run_id": "20260427T010916_615dbf", "timestamp_utc": "2026-04-27T01:09:16Z", "overall_status": "FAIL", "exit_code": 2, "health_score": 90, "git_commit": "d07fc801"}
+{"run_id": "20260427T011112_37a8f6", "timestamp_utc": "2026-04-27T01:11:12Z", "overall_status": "FAIL", "exit_code": 2, "health_score": 90, "git_commit": "d07fc801"}
+{"run_id": "20260427T011235_467110", "timestamp_utc": "2026-04-27T01:12:35Z", "overall_status": "FAIL", "exit_code": 2, "health_score": 90, "git_commit": "d07fc801"}
+{"run_id": "20260427T011446_bd4ab9", "timestamp_utc": "2026-04-27T01:14:46Z", "overall_status": "PASS", "exit_code": 0, "health_score": 100, "git_commit": "d07fc801"}
+{"run_id": "20260427T013149_352cb6", "timestamp_utc": "2026-04-27T01:31:49Z", "overall_status": "PASS", "exit_code": 0, "health_score": 100, "git_commit": "2f019fa8"}
+{"run_id": "20260427T015920_d32d96", "timestamp_utc": "2026-04-27T01:59:20Z", "overall_status": "PASS", "exit_code": 0, "health_score": 100, "git_commit": "315cb044"}
+{"run_id": "20260427T052836_97d3fa", "timestamp_utc": "2026-04-27T05:28:36Z", "overall_status": "PASS", "exit_code": 0, "health_score": 100, "git_commit": "12e9053f"}
+{"run_id": "20260427T054540_a57dda", "timestamp_utc": "2026-04-27T05:45:40Z", "overall_status": "PASS", "exit_code": 0, "health_score": 100, "git_commit": "12e9053f"}

--- a/_reports/session_start.json
+++ b/_reports/session_start.json
@@ -437,7 +437,7 @@
   ],
   "stage2_exit_code": 0,
   "hook_exit_code": 0,
-  "hook_validated_at": "2026-04-26T06:03:07.319439+00:00",
+  "hook_validated_at": "2026-04-27T02:01:26.540634+00:00",
   "module_focus": "notifications",
   "worker_prompt_sha256": "fbea2faed6111e58671c12e48a0894c0c1c6ead7aab2729df2742b103033dd03",
   "module": "notifications",


### PR DESCRIPTION
## Relatório pós-merge — RULE_CHANGE_QUARANTINE_GATE

Este PR contém apenas artefatos de relatório regenerados após o merge do PR #95.

### Evidências
- `overall_status: PASS`
- `active_gates_total: 69` (era 63 antes do PR #95)
- `RULE_CHANGE_QUARANTINE_GATE: PASS`
- Contenções 1 e 2 do HBCONTROL.md implementadas e validadas

### Arquivos alterados
- `_reports/contract_gates/latest.json` — gate report atualizado
- `_reports/pipeline_health.json` — health snapshot
- `_reports/pipeline_history.jsonl` — histórico de execuções
- `SESSION_HANDOFF.md` — branch_ativo atualizado
- Demais relatórios de evidência

### Restrição
Nenhum arquivo de `src/`, `frontend/`, `contracts/`, `migrations/` foi alterado.

Refs: #95 (12e9053f)