### PR TITLE
test(core): burn down teams and seasons placeholders

### DIFF
--- a/src/seasons/tests/integration/test_seasons_api.py
+++ b/src/seasons/tests/integration/test_seasons_api.py
@@ -1,11 +1,86 @@
 """
-Testes de integração — módulo seasons.
-Skeleton: requer PostgreSQL + Django configurado.
-Executar separado do suite unitário.
+Testes de integração do módulo seasons.
 """
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+import uuid
+
 import pytest
 
+from identity_access.domain.entities import AuthSession
+from identity_access.infrastructure.jwt_adapter import JWTAdapter
+from seasons.infrastructure.models import SeasonModel
 
-def test_placeholder():
-    """Placeholder — suite de integração seasons a implementar."""
-    pass
+ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000201")
+COACH_ID = uuid.UUID("00000000-0000-0000-0000-000000000202")
+TEAM_ID = uuid.UUID("00000000-0000-0000-0000-000000000203")
+SEASON_ID = uuid.UUID("00000000-0000-0000-0000-000000000204")
+
+
+def _make_jwt(
+    user_id: uuid.UUID,
+    monkeypatch: pytest.MonkeyPatch,
+    role: str = "coach",
+) -> str:
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("JWT_SECRET", "seasons-integration-secret")
+    session = AuthSession(
+        id=uuid.uuid4(),
+        principal_user_id=user_id,
+        session_scope_label="full",
+        role_labels=[role],
+        auth_method_label="password",
+        mfa_required=False,
+        mfa_satisfied=True,
+        issued_at=datetime.now(tz=timezone.utc),
+        expires_at=datetime.now(tz=timezone.utc),
+        revoked_at=None,
+    )
+    return JWTAdapter().issue_access_token(session)
+
+
+@pytest.mark.django_db
+def test_list_seasons_requires_authenticated_actor(client):
+    response = client.get("/api/seasons")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Unauthenticated"
+
+
+@pytest.mark.django_db
+def test_list_seasons_returns_seeded_season_for_authenticated_actor(client, monkeypatch):
+    SeasonModel.objects.create(
+        id=SEASON_ID,
+        organization_id=ORG_ID,
+        name="Temporada 2026",
+        sport_cycle_label="handebol",
+        status_label="ACTIVE",
+        start_date=date(2026, 1, 10),
+        end_date=date(2026, 12, 20),
+        phase_labels=["preparacao", "competicao"],
+        team_ids=[str(TEAM_ID)],
+        competition_ids=[],
+    )
+    auth = f"Bearer {_make_jwt(COACH_ID, monkeypatch)}"
+
+    response = client.get("/api/seasons", HTTP_AUTHORIZATION=auth)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"] == 1
+    assert payload["page_size"] == 20
+    assert payload["total"] == 1
+    season = payload["data"][0]
+    assert season["id"] == str(SEASON_ID)
+    assert season["name"] == "Temporada 2026"
+    assert season["start_date"] == "2026-01-10"
+    assert season["end_date"] == "2026-12-20"
+    assert season["status_label"] == "ACTIVE"
+    assert season["phase_labels"] == ["preparacao", "competicao"]
+    assert season["team_ids"] == [str(TEAM_ID)]
+    assert season["competition_ids"] == []
+    assert season["organization_id"] == str(ORG_ID)
+    assert season["sport_cycle_label"] == "handebol"
+    assert season["created_at"]
+    assert season["updated_at"]

--- a/src/teams/tests/integration/test_teams_api.py
+++ b/src/teams/tests/integration/test_teams_api.py
@@ -1,11 +1,83 @@
 """
-Testes de integração — módulo teams.
-Skeleton: requer PostgreSQL + Django configurado.
-Executar separado do suite unitário.
+Testes de integração do módulo teams.
 """
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+
 import pytest
 
+from identity_access.domain.entities import AuthSession
+from identity_access.infrastructure.jwt_adapter import JWTAdapter
+from teams.infrastructure.models import TeamModel
 
-def test_placeholder():
-    """Placeholder — suite de integração teams a implementar."""
-    pass
+ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000101")
+ADMIN_ID = uuid.UUID("00000000-0000-0000-0000-000000000102")
+TEAM_ID = uuid.UUID("00000000-0000-0000-0000-000000000103")
+
+
+def _make_jwt(
+    user_id: uuid.UUID,
+    monkeypatch: pytest.MonkeyPatch,
+    role: str = "admin",
+) -> str:
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("JWT_SECRET", "teams-integration-secret")
+    session = AuthSession(
+        id=uuid.uuid4(),
+        principal_user_id=user_id,
+        session_scope_label="full",
+        role_labels=[role],
+        auth_method_label="password",
+        mfa_required=False,
+        mfa_satisfied=True,
+        issued_at=datetime.now(tz=timezone.utc),
+        expires_at=datetime.now(tz=timezone.utc),
+        revoked_at=None,
+    )
+    return JWTAdapter().issue_access_token(session)
+
+
+@pytest.mark.django_db
+def test_list_teams_requires_authenticated_actor(client):
+    response = client.get("/api/teams")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Unauthenticated"
+
+
+@pytest.mark.django_db
+def test_list_teams_returns_seeded_team_for_authenticated_actor(client, monkeypatch):
+    TeamModel.objects.create(
+        id=TEAM_ID,
+        organization_id=ORG_ID,
+        name="Adulto Masculino A",
+        short_name="HB A",
+        category_label="adulto_masculino",
+        status_label="ACTIVE",
+        athlete_ids=[],
+        staff_user_ids=[str(ADMIN_ID)],
+    )
+    auth = f"Bearer {_make_jwt(ADMIN_ID, monkeypatch)}"
+
+    response = client.get("/api/teams", HTTP_AUTHORIZATION=auth)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"] == 1
+    assert payload["page_size"] == 20
+    assert payload["total"] == 1
+    team = payload["data"][0]
+    assert team["id"] == str(TEAM_ID)
+    assert team["organization_id"] == str(ORG_ID)
+    assert team["name"] == "Adulto Masculino A"
+    assert team["category_label"] == "adulto_masculino"
+    assert team["status_label"] == "ACTIVE"
+    assert team["season_id"] is None
+    assert team["short_name"] == "HB A"
+    assert team["athlete_ids"] == []
+    assert team["staff_user_ids"] == [str(ADMIN_ID)]
+    assert team["roster_notes"] is None
+    assert team["created_at"]
+    assert team["updated_at"]


### PR DESCRIPTION
## Summary
- replace the `teams` integration placeholder with real auth and list coverage
- replace the `seasons` integration placeholder with real auth and list coverage
- keep the PR scoped to test files only, with no governance or enforcement changes

## Validation
- `SECRET_KEY=codex-local-phase1-core-key-1234567890 ALLOWED_HOSTS=localhost,127.0.0.1 pytest -q src/teams/tests/integration/test_teams_api.py src/seasons/tests/integration/test_seasons_api.py`
- `SECRET_KEY=codex-local-phase1-core-key-1234567890 ALLOWED_HOSTS=localhost,127.0.0.1 pytest -q src/teams/tests src/seasons/tests`
- `python3 scripts/hb validate --profile ci` was attempted in the clean worktree and failed for pre-existing local environment reasons: missing `redocly`, `spectral`, `asyncapi`, plus `HANDOFF_COHERENCE_GATE` because `SESSION_HANDOFF.md` still points to another branch
