### PR TITLE
perf(pipeline): add validation timing script

### DIFF
--- a/scripts/dev/measure_pipeline_perf.sh
+++ b/scripts/dev/measure_pipeline_perf.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+log_section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+run_timed() {
+  local label="$1"
+  shift
+  log_section "$label"
+  printf '+ %q' "$1"
+  shift || true
+  for arg in "$@"; do
+    printf ' %q' "$arg"
+  done
+  printf '\n'
+  time "$@"
+}
+
+log_section "HB Track pipeline performance measurement"
+printf 'Repository: %s\n' "$ROOT"
+printf 'Branch: %s\n' "$(git branch --show-current 2>/dev/null || echo unknown)"
+printf 'Commit: %s\n' "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+printf 'Python: %s\n' "$(python3 --version 2>&1)"
+printf 'Node: %s\n' "$(node --version 2>/dev/null || echo unavailable)"
+printf 'npm: %s\n' "$(npm --version 2>/dev/null || echo unavailable)"
+
+run_timed "1) hb validate local" \
+  python3 scripts/hb validate --profile local
+
+run_timed "2) compile api policy check" \
+  python3 scripts/contracts/validate/api/compile_api_policy.py --all --check
+
+run_timed "3) contracts lint" \
+  npm run contracts:lint
+
+log_section "Done"


### PR DESCRIPTION
## Objetivo

Primeiro PR da issue #103 para acelerar comandos Python sem enfraquecer gates.

Este PR adiciona apenas medição inicial. Ele não altera a semântica dos gates, não adiciona cache e não cria perfis rápidos ainda.

## O que muda

Adiciona:

```text
scripts/dev/measure_pipeline_perf.sh
```

O script mede, em sequência:

```bash
python3 scripts/hb validate --profile local
python3 scripts/contracts/validate/api/compile_api_policy.py --all --check
npm run contracts:lint
```

Também imprime metadados básicos:

```text
repo root
branch
commit
python version
node version
npm version
```

## Relação com a issue

Refs #103

## Critério de segurança

Este PR não cria atalho de aprovação. O script é observacional: mede o tempo dos comandos existentes e preserva `local`/CI como autoridade final.

## Próximos passos fora deste PR

- Coletar tempos reais no ambiente local/CI.
- Identificar gargalos com `cProfile`/`pyinstrument` se necessário.
- Só depois propor `hb validate --profile quick/openapi/changed`.