### PR TITLE
fix(deploy): add GH_TOKEN to validate job — fix LIVE_ENFORCEMENT_PARITY_GATE regression on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,8 @@ jobs:
         run: pip install -r requirements-dev.txt
       - name: Run contract gates
         run: python3 scripts/contracts/validate/validate_contracts.py
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   # ─────────────────────────────────────────────────────────────
   # ETAPA 2: Testes

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,25 +1,25 @@
 ---
-data_ultima_sessao: "2026-04-29"
-branch_ativo: chore/openapi-lint-toolchain-scripts
+data_ultima_sessao: "2026-04-30"
+branch_ativo: fix/deploy-live-enforcement-parity-gh-token
 modo_operacao: CDD
 ci_status: UNKNOWN
 modulo_foco: notifications
 fase_roadmap: 1
-task_type: architecture_review
+task_type: pr_fix
 boot_profile_id: architecture_decision
-task_id: MULTIAGENT_ARCH
+task_id: FIX_DEPLOY_GH_TOKEN
 resultado: PENDENTE
-proxima_acao_permitida: "Aguardar CI do push — pr_fix aplicado, HANDOFF_COHERENCE_GATE resolvido localmente."
+proxima_acao_permitida: "Aguardar CI do PR fix — GH_TOKEN adicionado ao deploy.yml step 1."
 bloqueios_ativos: []
 evidence_paths:
-  - "tests/pipeline_gates/test_platform_agent_exposure.py"
+  - ".github/workflows/deploy.yml"
 ---
-# SESSION HANDOFF — MULTIAGENT_ARCH
+# SESSION HANDOFF — FIX_DEPLOY_GH_TOKEN
 
 ## Estado Geral
-**Data:** 2026-04-29 | **Branch:** chore/openapi-lint-toolchain-scripts | **CI:** UNKNOWN
-**Modo:** CDD | **task_type:** architecture_review | **boot_profile:** architecture_decision
-**Módulo foco:** notifications | **Fase ROADMAP:** 1 | **task_id:** MULTIAGENT_ARCH | **Resultado:** PENDENTE
+**Data:** 2026-04-30 | **Branch:** fix/deploy-live-enforcement-parity-gh-token | **CI:** UNKNOWN
+**Modo:** CDD | **task_type:** pr_fix | **boot_profile:** architecture_decision
+**Módulo foco:** openapi | **Fase ROADMAP:** 1 | **task_id:** FIX_DEPLOY_GH_TOKEN | **Resultado:** PENDENTE
 
 ## O que foi feito
 Implementação completa da arquitetura multiagente auditável conforme `.dev/PLANO.md` com correções A1-A8:


### PR DESCRIPTION
## Problema

Após o merge do PR #102, o workflow `HB Track — Deploy Pipeline` (`deploy.yml`) falha no job `1. Validate Contracts` com:

```
LIVE_ENFORCEMENT_PARITY_GATE: FAIL
Falha ao obter ruleset live: gh: To use GitHub CLI in a GitHub Actions workflow,
set the GH_TOKEN environment variable.
```

## Causa raiz

O `validate_contracts.py` (rodado diretamente pelo `deploy.yml`) usa o `gh` CLI para verificar rulesets no `LIVE_ENFORCEMENT_PARITY_GATE`. O job `validate` em `deploy.yml` não tinha `GH_TOKEN` no env do step.

O `_reusable-ci.yml` (que dispara `ci / Validate Contracts`) já tinha o fix correto na linha 70:
```yaml
env:
  GH_TOKEN: ${{ github.token }}
```

## Fix

Adicionado `GH_TOKEN: ${{ github.token }}` ao step `Run contract gates` em `deploy.yml`, idêntico ao padrão já usado em `_reusable-ci.yml`.

## Validação local

- `validate --profile ci`: ✅ PASS (todos gates incluindo `LIVE_ENFORCEMENT_PARITY_GATE`)
- `actionlint`: ✅ sem erros
- pre-commit hook: ✅ PARTIAL_PASS

Fixes: regressão detectada pós-merge do PR #102.