### PR TITLE
test(gates): negative enforcement tests for OpenAPI, AsyncAPI and agent governance (#108)

### DIFF
--- a/.github/workflows/contract-gates.yml
+++ b/.github/workflows/contract-gates.yml
@@ -320,3 +320,56 @@ jobs:
         run: python -m pytest tests/pipeline_gates/test_session_state_phase3.py -v
         env:
           GH_TOKEN: ${{ github.token }}
+
+  # ── Negative Enforcement (issue #108) ────────────────────────────────────
+  # Prova que OPENAPI_POLICY_RULESET_GATE, ASYNCAPI_VALIDATION_GATE e os
+  # gates pytest de agent governance falham sob violação controlada. Gera
+  # _reports/implementation_flow/negative_test_manifest.json validado contra
+  # contracts/schemas/shared/negative_test_manifest.schema.json e o publica
+  # como artifact. Roda em todo PR — não depende de path filter.
+  negative-enforcement:
+    name: Negative Enforcement Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ler versões de toolchain.json
+        id: versions
+        run: |
+          echo "node=$(jq -r .runtimes.node toolchain.json)" >> "$GITHUB_OUTPUT"
+          echo "python=$(jq -r .runtimes.python toolchain.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.versions.outputs.node }}
+          cache: "npm"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ steps.versions.outputs.python }}
+
+      - name: Install Python dependencies
+        run: pip install -r scripts/_policy/requirements.txt pytest jsonschema PyYAML
+
+      - name: Install Node dependencies (spectral, asyncapi)
+        run: npm ci
+
+      - name: Run negative enforcement tests + generate manifest
+        run: |
+          python3 scripts/generate_negative_test_manifest.py \
+            --pr-url "${{ github.event.pull_request.html_url || format('https://github.com/{0}/commit/{1}', github.repository, github.sha) }}"
+
+      - name: Upload negative test manifest
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: negative-test-manifest
+          path: |
+            _reports/implementation_flow/negative_test_manifest.json
+            _reports/implementation_flow/negative_tests.junit.xml
+          retention-days: 30
+          if-no-files-found: error

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -9,7 +9,7 @@ task_type: implementation_execution
 boot_profile_id: contract_execution
 task_id: NEGATIVE_ENFORCEMENT_TESTS_ISSUE_108
 resultado: PENDENTE
-proxima_acao_permitida: "Abrir PR para issue #108. Verdict local PASS, coverage_ratio=1.0 (21/21 PROTECTED). Aguardando CI remoto."
+proxima_acao_permitida: "Aguardar CI verde no PR #112. Após CI verde: squash merge em main, fechar issue #108, iniciar PR B."
 bloqueios_ativos: []
 evidence_paths:
   - "tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py"
@@ -45,7 +45,7 @@ PR A da estratégia "frente A vs frente B" — provar que os gates falham sob vi
 - `NEGATIVE_TEST_COVERAGE_GATE` continua SKIP_NOT_APPLICABLE: o gate só ativa quando `implementation_flow_active=true` (current_state.json + IMPLEMENTATION_PR_OPENED). Esperado.
 
 ## Próxima ação permitida
-Commitar (3 testes + script + workflow + handoff + manifesto), push, abrir PR contra `main` referenciando issue #108. Aguardar CI remoto verde.
+Aguardar CI verde no PR #112 (https://github.com/hbtrack/official/pull/112). Após CI verde: squash merge em main, fechar issue #108, iniciar PR B.
 
 ## Bloqueios ativos
 - Nenhum.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -37,21 +37,12 @@ PR A da estratégia "frente A vs frente B" — provar que os gates falham sob vi
 - `.github/workflows/contract-gates.yml` — novo job `negative-enforcement` que roda os 3 test files, gera o manifesto e publica como artifact (com `pr_url` real do PR remoto)
 
 ## Evidências
-- 24 testes locais: PASS (3 baselines + 21 negativos)
-- Manifesto gerado: `_reports/implementation_flow/negative_test_manifest.json`
-  - `verdict=PASS`, `coverage_ratio=1.0` (21 PROTECTED, 0 UNPROTECTED)
-  - schema-valid contra `contracts/schemas/shared/negative_test_manifest.schema.json`
-- Pipeline `hb validate --profile ci`: bloqueado APENAS por HANDOFF_COHERENCE (este arquivo, agora atualizado)
-- `NEGATIVE_TEST_COVERAGE_GATE` continua SKIP_NOT_APPLICABLE: o gate só ativa quando `implementation_flow_active=true` (current_state.json + IMPLEMENTATION_PR_OPENED). Esperado.
+- 24 testes: PASS (3 baselines + 21 negativos)
+- Manifesto: `_reports/implementation_flow/negative_test_manifest.json` — `verdict=PASS`, `coverage_ratio=1.0`
+- `hb validate --profile ci`: PASS (exceto HANDOFF_COHERENCE, resolvido neste commit)
 
 ## Próxima ação permitida
-Aguardar CI verde no PR #112 (https://github.com/hbtrack/official/pull/112). Após CI verde: squash merge em main, fechar issue #108, iniciar PR B.
+CI verde no PR #112 → squash merge → fechar issue #108.
 
 ## Bloqueios ativos
 - Nenhum.
-
-## Próximos PRs (estratégia frente B)
-- **PR B**: LIVE_ENFORCEMENT_PARITY_GATE local como `ERROR_INFRA` (separar ruído WSL de falha semântica)
-- **PR C**: waiver hygiene (remover waiver expirado + teste anti-zumbi)
-- **PR D**: issue #111 — TRAINING_DECISION_MATERIALIZATION_BACKFILL (TRAIN-DEC-001/004/006/007/008/012)
-- **PR E**: TRAIN-DEC-020 (audit_event_emitted.yaml) e TRAIN-DEC-047 (exercise_id boundary) — conflitos contratuais R1/R2

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,58 +1,57 @@
 ---
-data_ultima_sessao: "2026-04-30"
-branch_ativo: feat/decision-materialization-gate
+data_ultima_sessao: "2026-05-01"
+branch_ativo: feat/negative-enforcement-tests
 modo_operacao: CDD
 ci_status: UNKNOWN
 modulo_foco: training
 fase_roadmap: 1
-task_type: new_contract
+task_type: implementation_execution
 boot_profile_id: contract_execution
-task_id: DECISION_MATERIALIZATION_GATE
+task_id: NEGATIVE_ENFORCEMENT_TESTS_ISSUE_108
 resultado: PENDENTE
-proxima_acao_permitida: "PR 2 (#110) — 3 fixes Codex aplicados (commit 13766123, pushed). 3 threads Codex respondidos e resolvidos. CI rodando no novo commit. Aguardando CI pass + review approval para merge. Proxima acao: merge PR #110, iniciar PR 3 (TRAINING_DECISION_MATERIALIZATION_BACKFILL)."
+proxima_acao_permitida: "Abrir PR para issue #108. Verdict local PASS, coverage_ratio=1.0 (21/21 PROTECTED). Aguardando CI remoto."
 bloqueios_ativos: []
 evidence_paths:
-  - "scripts/contracts/validate/validate_contracts.py"
-  - "docs/_canon/gates/GATES_REGISTRY.yaml"
-  - "_reports/decision_materialization/training.json"
-  - "tests/pipeline_gates/test_decision_materialization_gate.py"
+  - "tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py"
+  - "tests/pipeline_gates/test_asyncapi_validation_gate_negative.py"
+  - "tests/pipeline_gates/test_agent_governance_negative_enforcement.py"
+  - "scripts/generate_negative_test_manifest.py"
+  - ".github/workflows/contract-gates.yml"
+  - "_reports/implementation_flow/negative_test_manifest.json"
 ---
-# SESSION HANDOFF — DECISION_MATERIALIZATION_CANON_BOOTSTRAP
+# SESSION HANDOFF — NEGATIVE_ENFORCEMENT_TESTS (Issue #108)
 
 ## Estado Geral
-**Data:** 2026-04-30 | **Branch:** fix/deploy-live-enforcement-parity-gh-token | **CI:** UNKNOWN
-**Modo:** CDD | **task_type:** pr_fix | **boot_profile:** architecture_decision
-**Módulo foco:** openapi | **Fase ROADMAP:** 1 | **task_id:** FIX_DEPLOY_GH_TOKEN | **Resultado:** PENDENTE
+**Data:** 2026-05-01 | **Branch:** feat/negative-enforcement-tests | **CI:** UNKNOWN
+**Modo:** CDD | **task_type:** implementation_execution | **boot_profile:** contract_execution
+**Módulo foco:** training (alinhado a session_start; trabalho cross-cutting OpenAPI/AsyncAPI/agent-governance) | **Fase ROADMAP:** 1 | **task_id:** NEGATIVE_ENFORCEMENT_TESTS_ISSUE_108 | **Resultado:** PENDENTE
 
 ## O que foi feito
-Implementação completa da arquitetura multiagente auditável conforme `.dev/PLANO.md` com correções A1-A8:
+PR A da estratégia "frente A vs frente B" — provar que os gates falham sob violação controlada antes de corrigir as decisões expostas pelo PR #110.
 
-- **PLANO.md** atualizado com 8 correções de auditoria (C1-C6 eliminados)
-- **`.dev/AGENT_PLATFORM_EXPOSURE_EXECUTION_PLAN.md`** atualizado — "Regras fechadas" removidas, "Evolução arquitetural" adicionada
-- **`.dev/schemas/hb_gate_report.schema.json`** criado (experimental, não em contracts/)
-- **`.dev/evidence/gates/planning_gate_report.json`** criado como exemplo de gate report
-- **Agentes Copilot** atualizados cirurgicamente:
-  - `hb-implementer`: 3º handoff adicionado (`Hb Adversarial Tester`, `send: false`)
-  - `hb-adversarial-tester`: HandTracker handoff `send: true → false` + seção pacote isolado
-  - `Mesclado` (HandTracker): seção "Estados operacionais" adicionada
-- **`.claude/agents/`** criado com 3 subagents (hb-adversarial-tester, hb-governance-auditor, hb-evidence-verifier)
-- **`.dev/codex-agents/`** criado com 2 gate agents (hb-gate-auditor, hb-pr-reviewer)
-- **Bridge docs** atualizados: AGENTS.md, CLAUDE.md, .codex, MAP.md — frases testadas preservadas
-- **`test_gate_report_schema.py`** criado: 14 testes (7 positivos + 7 negativos)
-- **`test_platform_agent_exposure.py`** estendido: 35 testes total (23 novos, itens 11-22)
-- **Resultado de testes:** 98/98 PASS (6 suítes de pipeline_gates)
+- 3 test files novos em `tests/pipeline_gates/`:
+  - `test_openapi_policy_ruleset_gate_negative.py` — 9 testes (1 baseline + 8 negativos cobrindo as 8 regras `error` de `.spectral.yaml`)
+  - `test_asyncapi_validation_gate_negative.py` — 7 testes (1 baseline + 6 negativos cobrindo schema, versão, info, channels, YAML)
+  - `test_agent_governance_negative_enforcement.py` — 8 testes (1 baseline + 7 negativos cobrindo `.github/agents/`, frontmatter, bridge docs CLAUDE.md/.codex, doc de plano de exposição)
+- `scripts/generate_negative_test_manifest.py` — gera `_reports/implementation_flow/negative_test_manifest.json` validado contra `contracts/schemas/shared/negative_test_manifest.schema.json` (schema canônico já existente)
+- `.github/workflows/contract-gates.yml` — novo job `negative-enforcement` que roda os 3 test files, gera o manifesto e publica como artifact (com `pr_url` real do PR remoto)
 
 ## Evidências
-- `tests/pipeline_gates/test_platform_agent_exposure.py` — 35/35 PASS
-- `tests/pipeline_gates/test_gate_report_schema.py` — 14/14 PASS
-- `tests/pipeline_gates/test_agent_compliance_phase0.py` — PASS
-- `tests/pipeline_gates/test_agent_operability_matrix.py` — PASS
-- `tests/pipeline_gates/test_implementation_execution_boot.py` — PASS
-- `tests/pipeline_gates/test_implementation_flow_gates.py` — PASS
-- `governance_changed = false` para arquivos criados por esta trilha (nenhum em .contract_driven/, docs/_canon/)
+- 24 testes locais: PASS (3 baselines + 21 negativos)
+- Manifesto gerado: `_reports/implementation_flow/negative_test_manifest.json`
+  - `verdict=PASS`, `coverage_ratio=1.0` (21 PROTECTED, 0 UNPROTECTED)
+  - schema-valid contra `contracts/schemas/shared/negative_test_manifest.schema.json`
+- Pipeline `hb validate --profile ci`: bloqueado APENAS por HANDOFF_COHERENCE (este arquivo, agora atualizado)
+- `NEGATIVE_TEST_COVERAGE_GATE` continua SKIP_NOT_APPLICABLE: o gate só ativa quando `implementation_flow_active=true` (current_state.json + IMPLEMENTATION_PR_OPENED). Esperado.
 
 ## Próxima ação permitida
-Corrigir HANDOFF_COHERENCE_GATE: push do fix (evidence_paths sem referência gitignored) → CI reativo.
+Commitar (3 testes + script + workflow + handoff + manifesto), push, abrir PR contra `main` referenciando issue #108. Aguardar CI remoto verde.
 
 ## Bloqueios ativos
-- Nenhum (pr_fix aplicado: referência gitignored removida de `evidence_paths`; validate --profile ci PASS local)
+- Nenhum.
+
+## Próximos PRs (estratégia frente B)
+- **PR B**: LIVE_ENFORCEMENT_PARITY_GATE local como `ERROR_INFRA` (separar ruído WSL de falha semântica)
+- **PR C**: waiver hygiene (remover waiver expirado + teste anti-zumbi)
+- **PR D**: issue #111 — TRAINING_DECISION_MATERIALIZATION_BACKFILL (TRAIN-DEC-001/004/006/007/008/012)
+- **PR E**: TRAIN-DEC-020 (audit_event_emitted.yaml) e TRAIN-DEC-047 (exercise_id boundary) — conflitos contratuais R1/R2

--- a/_reports/implementation_flow/negative_test_manifest.json
+++ b/_reports/implementation_flow/negative_test_manifest.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": "1.0.0",
+  "pr_url": "https://github.com/hbtrack/official/pull/0",
+  "decision_ids_tested": [],
+  "rules_tested": [
+    {
+      "rule_id": "hbtrack-openapi-version",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "openapi version diferente de 3.1.x",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_openapi_version_violated",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "hbtrack-operation-id-required",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "operação HTTP sem operationId",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_operation_id_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "hbtrack-tag-description",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "tag declarada sem description",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_tag_description_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "hbtrack-no-uri-versioning",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "versão na URI (ex.: /v1/)",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_uri_versioning_present",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "hbtrack-info-title",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "info.title ausente",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_info_title_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "hbtrack-info-version",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "info.version ausente",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_info_version_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "hbtrack-servers-defined",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "servers ausente ou vazio",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_servers_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "hbtrack-problem-schema-declared",
+      "rule_source": ".spectral.yaml",
+      "prohibited_behavior": "components.schemas.problem ausente (RFC 7807)",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py::test_fail_when_problem_schema_undeclared",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "asyncapi-version-field-required",
+      "rule_source": "asyncapi-cli (validate)",
+      "prohibited_behavior": "campo top-level 'asyncapi' ausente",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_asyncapi_validation_gate_negative.py::test_fail_when_asyncapi_version_field_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "asyncapi-version-supported",
+      "rule_source": "asyncapi-cli (validate)",
+      "prohibited_behavior": "versão AsyncAPI inexistente / não suportada",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_asyncapi_validation_gate_negative.py::test_fail_when_asyncapi_version_unsupported",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "asyncapi-info-title-required",
+      "rule_source": "asyncapi-cli (validate)",
+      "prohibited_behavior": "info.title ausente em AsyncAPI",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_asyncapi_validation_gate_negative.py::test_fail_when_asyncapi_info_title_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "asyncapi-info-version-required",
+      "rule_source": "asyncapi-cli (validate)",
+      "prohibited_behavior": "info.version ausente em AsyncAPI",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_asyncapi_validation_gate_negative.py::test_fail_when_asyncapi_info_version_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "asyncapi-yaml-syntactically-valid",
+      "rule_source": "asyncapi-cli (validate)",
+      "prohibited_behavior": "YAML sintaticamente inválido",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_asyncapi_validation_gate_negative.py::test_fail_when_yaml_is_malformed",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "asyncapi-channels-required",
+      "rule_source": "asyncapi-cli (validate)",
+      "prohibited_behavior": "channels ausente em AsyncAPI 2.x",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_asyncapi_validation_gate_negative.py::test_fail_when_channels_field_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "agent-copilot-required-files",
+      "rule_source": "tests/pipeline_gates/test_platform_agent_exposure.py",
+      "prohibited_behavior": "arquivo de agente Copilot esperado ausente",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_agent_governance_negative_enforcement.py::test_fail_when_required_copilot_agent_missing",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "agent-frontmatter-name-matches-file",
+      "rule_source": "tests/pipeline_gates/test_platform_agent_exposure.py",
+      "prohibited_behavior": "frontmatter.name divergente do arquivo do agente",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_agent_governance_negative_enforcement.py::test_fail_when_agent_frontmatter_name_mismatches",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "agent-implementer-runtime-task-type-declared",
+      "rule_source": "tests/pipeline_gates/test_platform_agent_exposure.py",
+      "prohibited_behavior": "hb-implementer sem referência a implementation_execution",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_agent_governance_negative_enforcement.py::test_fail_when_implementer_missing_runtime_task_type",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "agent-handtracker-not-runtime-executor",
+      "rule_source": "tests/pipeline_gates/test_platform_agent_exposure.py",
+      "prohibited_behavior": "HandTracker apresentado como executor runtime",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_agent_governance_negative_enforcement.py::test_fail_when_handtracker_presented_as_runtime_executor",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "bridge-claude-declares-external-tester-role",
+      "rule_source": "CLAUDE.md",
+      "prohibited_behavior": "CLAUDE.md sem declaração de tester externo final",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_agent_governance_negative_enforcement.py::test_fail_when_claude_md_missing_external_tester_role",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "bridge-codex-declares-no-equivalent-ui",
+      "rule_source": ".codex",
+      "prohibited_behavior": ".codex sem declaração de não-equivalência de UI a Copilot",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_agent_governance_negative_enforcement.py::test_fail_when_codex_missing_no_equivalent_clause",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    },
+    {
+      "rule_id": "bridge-execution-plan-doc-required",
+      "rule_source": ".dev/AGENT_PLATFORM_EXPOSURE_EXECUTION_PLAN.md",
+      "prohibited_behavior": "doc dedicado de exposição por plataforma ausente",
+      "test_command": "python3 -m pytest tests/pipeline_gates/test_agent_governance_negative_enforcement.py::test_fail_when_execution_plan_doc_deleted",
+      "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+      "actual_result": "FAIL (gate detectou a violação injetada — comportamento esperado)",
+      "verdict": "PROTECTED"
+    }
+  ],
+  "coverage_ratio": 1.0,
+  "verdict": "PASS"
+}

--- a/scripts/generate_negative_test_manifest.py
+++ b/scripts/generate_negative_test_manifest.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+Gera _reports/implementation_flow/negative_test_manifest.json a partir da
+execução dos test files de negative enforcement (issue #108).
+
+Cada teste pytest é mapeado para um item em `rules_tested[]`. O verdict do item
+é PROTECTED se o teste passou (gate detectou a violação injetada) e UNPROTECTED
+caso contrário. O verdict global é PASS se coverage_ratio >= 0.80 e nenhum
+UNPROTECTED.
+
+O manifesto é validado contra contracts/schemas/shared/negative_test_manifest.schema.json
+antes de ser escrito.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from xml.etree import ElementTree as ET
+
+import jsonschema
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+TESTS = [
+    "tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py",
+    "tests/pipeline_gates/test_asyncapi_validation_gate_negative.py",
+    "tests/pipeline_gates/test_agent_governance_negative_enforcement.py",
+]
+SCHEMA_PATH = REPO_ROOT / "contracts" / "schemas" / "shared" / "negative_test_manifest.schema.json"
+OUTPUT_PATH = REPO_ROOT / "_reports" / "implementation_flow" / "negative_test_manifest.json"
+PR_URL_PLACEHOLDER = "https://github.com/hbtrack/official/pull/0"
+COVERAGE_THRESHOLD = 0.80
+
+
+# Mapeamento test_name → (rule_id, rule_source, prohibited_behavior).
+# rule_source aponta o arquivo SSOT que define a regra.
+TEST_RULE_MAP: dict[str, tuple[str, str, str]] = {
+    # OpenAPI ruleset
+    "test_fail_when_openapi_version_violated": (
+        "hbtrack-openapi-version",
+        ".spectral.yaml",
+        "openapi version diferente de 3.1.x",
+    ),
+    "test_fail_when_operation_id_missing": (
+        "hbtrack-operation-id-required",
+        ".spectral.yaml",
+        "operação HTTP sem operationId",
+    ),
+    "test_fail_when_tag_description_missing": (
+        "hbtrack-tag-description",
+        ".spectral.yaml",
+        "tag declarada sem description",
+    ),
+    "test_fail_when_uri_versioning_present": (
+        "hbtrack-no-uri-versioning",
+        ".spectral.yaml",
+        "versão na URI (ex.: /v1/)",
+    ),
+    "test_fail_when_info_title_missing": (
+        "hbtrack-info-title",
+        ".spectral.yaml",
+        "info.title ausente",
+    ),
+    "test_fail_when_info_version_missing": (
+        "hbtrack-info-version",
+        ".spectral.yaml",
+        "info.version ausente",
+    ),
+    "test_fail_when_servers_missing": (
+        "hbtrack-servers-defined",
+        ".spectral.yaml",
+        "servers ausente ou vazio",
+    ),
+    "test_fail_when_problem_schema_undeclared": (
+        "hbtrack-problem-schema-declared",
+        ".spectral.yaml",
+        "components.schemas.problem ausente (RFC 7807)",
+    ),
+    # AsyncAPI
+    "test_fail_when_asyncapi_version_field_missing": (
+        "asyncapi-version-field-required",
+        "asyncapi-cli (validate)",
+        "campo top-level 'asyncapi' ausente",
+    ),
+    "test_fail_when_asyncapi_version_unsupported": (
+        "asyncapi-version-supported",
+        "asyncapi-cli (validate)",
+        "versão AsyncAPI inexistente / não suportada",
+    ),
+    "test_fail_when_asyncapi_info_title_missing": (
+        "asyncapi-info-title-required",
+        "asyncapi-cli (validate)",
+        "info.title ausente em AsyncAPI",
+    ),
+    "test_fail_when_asyncapi_info_version_missing": (
+        "asyncapi-info-version-required",
+        "asyncapi-cli (validate)",
+        "info.version ausente em AsyncAPI",
+    ),
+    "test_fail_when_yaml_is_malformed": (
+        "asyncapi-yaml-syntactically-valid",
+        "asyncapi-cli (validate)",
+        "YAML sintaticamente inválido",
+    ),
+    "test_fail_when_channels_field_missing": (
+        "asyncapi-channels-required",
+        "asyncapi-cli (validate)",
+        "channels ausente em AsyncAPI 2.x",
+    ),
+    # Agent governance
+    "test_fail_when_required_copilot_agent_missing": (
+        "agent-copilot-required-files",
+        "tests/pipeline_gates/test_platform_agent_exposure.py",
+        "arquivo de agente Copilot esperado ausente",
+    ),
+    "test_fail_when_agent_frontmatter_name_mismatches": (
+        "agent-frontmatter-name-matches-file",
+        "tests/pipeline_gates/test_platform_agent_exposure.py",
+        "frontmatter.name divergente do arquivo do agente",
+    ),
+    "test_fail_when_implementer_missing_runtime_task_type": (
+        "agent-implementer-runtime-task-type-declared",
+        "tests/pipeline_gates/test_platform_agent_exposure.py",
+        "hb-implementer sem referência a implementation_execution",
+    ),
+    "test_fail_when_handtracker_presented_as_runtime_executor": (
+        "agent-handtracker-not-runtime-executor",
+        "tests/pipeline_gates/test_platform_agent_exposure.py",
+        "HandTracker apresentado como executor runtime",
+    ),
+    "test_fail_when_claude_md_missing_external_tester_role": (
+        "bridge-claude-declares-external-tester-role",
+        "CLAUDE.md",
+        "CLAUDE.md sem declaração de tester externo final",
+    ),
+    "test_fail_when_codex_missing_no_equivalent_clause": (
+        "bridge-codex-declares-no-equivalent-ui",
+        ".codex",
+        ".codex sem declaração de não-equivalência de UI a Copilot",
+    ),
+    "test_fail_when_execution_plan_doc_deleted": (
+        "bridge-execution-plan-doc-required",
+        ".dev/AGENT_PLATFORM_EXPOSURE_EXECUTION_PLAN.md",
+        "doc dedicado de exposição por plataforma ausente",
+    ),
+}
+
+
+def _run_pytest(junit_xml: pathlib.Path) -> int:
+    """Roda pytest sobre os 3 test files, gravando JUnit XML."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        *TESTS,
+        f"--junitxml={junit_xml}",
+        "-q",
+        "--no-header",
+        "-p",
+        "no:cacheprovider",
+    ]
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode not in (0, 1):  # 0=all pass, 1=some failed
+        sys.stderr.write(f"pytest exit code inesperado: {proc.returncode}\n")
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+    return proc.returncode
+
+
+def _parse_junit(junit_xml: pathlib.Path) -> list[dict]:
+    """Extrai resultados por teste do JUnit XML."""
+    results: list[dict] = []
+    tree = ET.parse(junit_xml)
+    for testcase in tree.iter("testcase"):
+        name = testcase.get("name") or ""
+        classname = testcase.get("classname") or ""
+        failed = any(child.tag in ("failure", "error") for child in testcase)
+        skipped = any(child.tag == "skipped" for child in testcase)
+        results.append({
+            "name": name,
+            "classname": classname,
+            "passed": not failed and not skipped,
+            "failed": failed,
+            "skipped": skipped,
+        })
+    return results
+
+
+def _build_rules_tested(results: list[dict]) -> list[dict]:
+    items: list[dict] = []
+    for r in results:
+        name = r["name"]
+        if name not in TEST_RULE_MAP:
+            # Baselines (test_baseline_*) e outros — ignorar
+            continue
+        rule_id, rule_source, prohibited = TEST_RULE_MAP[name]
+        if r["skipped"]:
+            verdict = "UNPROTECTED"
+            actual = "SKIPPED — toolchain ausente, regra não pôde ser verificada"
+        elif r["passed"]:
+            verdict = "PROTECTED"
+            actual = "FAIL (gate detectou a violação injetada — comportamento esperado)"
+        else:
+            verdict = "UNPROTECTED"
+            actual = "PASS ou erro inesperado (gate NÃO detectou a violação injetada)"
+        items.append({
+            "rule_id": rule_id,
+            "rule_source": rule_source,
+            "prohibited_behavior": prohibited,
+            "test_command": (
+                f"python3 -m pytest {r['classname'].replace('.', '/')}.py::{name}"
+            ),
+            "expected_result": "FAIL (gate retorna status FAIL ou AssertionError)",
+            "actual_result": actual,
+            "verdict": verdict,
+        })
+    return items
+
+
+def _resolve_pr_url(arg_pr_url: str | None) -> str:
+    if arg_pr_url:
+        return arg_pr_url
+    state_path = REPO_ROOT / "_reports" / "implementation_flow" / "current_state.json"
+    if state_path.exists():
+        try:
+            data = json.loads(state_path.read_text(encoding="utf-8"))
+            url = data.get("pr_url")
+            if url and url.startswith("http"):
+                return url
+        except (json.JSONDecodeError, OSError):
+            pass
+    return PR_URL_PLACEHOLDER
+
+
+def _resolve_decision_ids() -> list[str]:
+    """Lê decision_ids do current_state.json se disponível; senão lista vazia."""
+    state_path = REPO_ROOT / "_reports" / "implementation_flow" / "current_state.json"
+    if not state_path.exists():
+        return []
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+        ids = data.get("decision_ids_affected", [])
+        return [s for s in ids if isinstance(s, str) and s]
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-url", default=None, help="URL do PR remoto (opcional)")
+    parser.add_argument(
+        "--junit-out",
+        default=str(REPO_ROOT / "_reports" / "implementation_flow" / "negative_tests.junit.xml"),
+        help="Caminho do JUnit XML intermediário",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(OUTPUT_PATH),
+        help="Caminho do manifesto de saída",
+    )
+    parser.add_argument(
+        "--skip-pytest",
+        action="store_true",
+        help="Não roda pytest; usa --junit-out existente",
+    )
+    args = parser.parse_args()
+
+    junit_xml = pathlib.Path(args.junit_out)
+    output_path = pathlib.Path(args.output)
+    junit_xml.parent.mkdir(parents=True, exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_pytest:
+        _run_pytest(junit_xml)
+
+    if not junit_xml.exists():
+        sys.stderr.write(f"JUnit XML não encontrado em {junit_xml}\n")
+        return 2
+
+    results = _parse_junit(junit_xml)
+    rules = _build_rules_tested(results)
+    if not rules:
+        sys.stderr.write(
+            "Nenhuma regra mapeada nos testes — atualize TEST_RULE_MAP em "
+            f"{__file__} se adicionou testes novos.\n"
+        )
+        return 2
+
+    protected = sum(1 for r in rules if r["verdict"] == "PROTECTED")
+    coverage_ratio = round(protected / len(rules), 4)
+    has_unprotected = any(r["verdict"] == "UNPROTECTED" for r in rules)
+    if coverage_ratio >= COVERAGE_THRESHOLD and not has_unprotected:
+        verdict = "PASS"
+    elif coverage_ratio > 0 and has_unprotected:
+        verdict = "PARTIAL"
+    else:
+        verdict = "FAIL"
+
+    manifest = {
+        "schema_version": "1.0.0",
+        "pr_url": _resolve_pr_url(args.pr_url),
+        "decision_ids_tested": _resolve_decision_ids(),
+        "rules_tested": rules,
+        "coverage_ratio": coverage_ratio,
+        "verdict": verdict,
+    }
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(manifest, schema)
+
+    output_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    sys.stdout.write(
+        f"manifest: {output_path.relative_to(REPO_ROOT)} | "
+        f"verdict={verdict} | coverage_ratio={coverage_ratio} | "
+        f"rules={len(rules)} (PROTECTED={protected}, "
+        f"UNPROTECTED={len(rules) - protected})\n"
+    )
+    return 0 if verdict == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/pipeline_gates/test_agent_governance_negative_enforcement.py
+++ b/tests/pipeline_gates/test_agent_governance_negative_enforcement.py
@@ -1,0 +1,170 @@
+"""
+Negative enforcement tests for agent governance (issue #108).
+
+Cada teste constrói uma cópia mínima do repositório em tmp_path,
+viola UMA regra de agent governance (estrutura de .github/agents/, frontmatter,
+bridge docs CLAUDE.md/.codex), e asserta que a asserção do gate existente
+DISPARA AssertionError sob essa violação.
+
+A estratégia de monkeypatch sobre `ROOT` do módulo testado prova que a regra
+captura a violação — sem precisar reimplementar a lógica.
+"""
+from __future__ import annotations
+
+import importlib
+import pathlib
+import shutil
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+
+AGENT_FILES = (
+    "hb-contract.agent.md",
+    "hb-implementer.agent.md",
+    "hb-adversarial-tester.agent.md",
+    "Mesclado.agent.md",
+)
+
+BRIDGE_DOCS = ("CLAUDE.md", ".codex", "AGENTS.md")
+DEV_DOCS = (
+    ".dev/AGENT_PLATFORM_EXPOSURE_MAP.md",
+    ".dev/AGENT_PLATFORM_EXPOSURE_EXECUTION_PLAN.md",
+)
+
+
+def _seed_fake_repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Copia para tmp_path o conjunto mínimo de arquivos que o teste original lê."""
+    agents_src = REPO_ROOT / ".github" / "agents"
+    agents_dst = tmp_path / ".github" / "agents"
+    agents_dst.mkdir(parents=True, exist_ok=True)
+    for name in AGENT_FILES:
+        src = agents_src / name
+        if src.exists():
+            shutil.copy2(src, agents_dst / name)
+    for rel in BRIDGE_DOCS:
+        src = REPO_ROOT / rel
+        if src.exists():
+            (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, tmp_path / rel)
+    for rel in DEV_DOCS:
+        src = REPO_ROOT / rel
+        dst = tmp_path / rel
+        if src.exists():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+    return tmp_path
+
+
+@pytest.fixture
+def fake_repo(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Constrói repo fake em tmp_path e aponta o módulo real para ele via monkeypatch."""
+    _seed_fake_repo(tmp_path)
+    exposure_test = importlib.import_module(
+        "tests.pipeline_gates.test_platform_agent_exposure"
+    )
+    monkeypatch.setattr(exposure_test, "ROOT", tmp_path)
+    return tmp_path, exposure_test
+
+
+# ---------------------------------------------------------------------------
+# Sanidade: fixture não-violada deve passar nos testes existentes
+# ---------------------------------------------------------------------------
+
+def test_baseline_unmutated_repo_passes_existing_gate(fake_repo) -> None:
+    _, exposure_test = fake_repo
+    instance = exposure_test.TestCopilotAgentFiles()
+    instance.test_expected_copilot_agents_exist()
+    instance.test_copilot_agent_names_match_frontmatter()
+
+
+# ---------------------------------------------------------------------------
+# Negativos: cada um viola UMA regra
+# ---------------------------------------------------------------------------
+
+def test_fail_when_required_copilot_agent_missing(fake_repo) -> None:
+    """Remove hb-contract.agent.md → test_expected_copilot_agents_exist deve falhar."""
+    tmp_path, exposure_test = fake_repo
+    (tmp_path / ".github" / "agents" / "hb-contract.agent.md").unlink()
+    instance = exposure_test.TestCopilotAgentFiles()
+    with pytest.raises(AssertionError, match="hb-contract.agent.md"):
+        instance.test_expected_copilot_agents_exist()
+
+
+def test_fail_when_agent_frontmatter_name_mismatches(fake_repo) -> None:
+    """Renomeia o campo `name` no frontmatter de hb-contract → asserção falha."""
+    tmp_path, exposure_test = fake_repo
+    target = tmp_path / ".github" / "agents" / "hb-contract.agent.md"
+    text = target.read_text(encoding="utf-8")
+    mutated = text.replace("name: HB Contract", "name: Wrong Name")
+    assert mutated != text, "fixture inválida — string esperada não encontrada"
+    target.write_text(mutated, encoding="utf-8")
+    instance = exposure_test.TestCopilotAgentFiles()
+    with pytest.raises(AssertionError, match="hb-contract"):
+        instance.test_copilot_agent_names_match_frontmatter()
+
+
+def test_fail_when_implementer_missing_runtime_task_type(fake_repo) -> None:
+    """Remove referência a `implementation_execution` → asserção falha."""
+    tmp_path, exposure_test = fake_repo
+    target = tmp_path / ".github" / "agents" / "hb-implementer.agent.md"
+    text = target.read_text(encoding="utf-8")
+    mutated = text.replace("implementation_execution", "garbage_task_type")
+    assert mutated != text, "fixture inválida — string esperada não encontrada"
+    target.write_text(mutated, encoding="utf-8")
+    instance = exposure_test.TestCopilotAgentFiles()
+    with pytest.raises(AssertionError):
+        instance.test_implementer_references_runtime_task_type()
+
+
+def test_fail_when_handtracker_presented_as_runtime_executor(fake_repo) -> None:
+    """Adiciona task_type runtime ao Mesclado.agent.md → asserção falha."""
+    tmp_path, exposure_test = fake_repo
+    target = tmp_path / ".github" / "agents" / "Mesclado.agent.md"
+    text = target.read_text(encoding="utf-8")
+    mutated = text + "\n\nimplementation_execution\n"
+    target.write_text(mutated, encoding="utf-8")
+    instance = exposure_test.TestCopilotAgentFiles()
+    with pytest.raises(AssertionError):
+        instance.test_handtracker_is_not_presented_as_runtime_executor()
+
+
+def test_fail_when_claude_md_missing_external_tester_role(fake_repo) -> None:
+    """Remove menção a 'tester externo final' em CLAUDE.md → asserção falha."""
+    tmp_path, exposure_test = fake_repo
+    target = tmp_path / "CLAUDE.md"
+    text = target.read_text(encoding="utf-8")
+    mutated = text.replace("tester externo final", "REMOVED")
+    assert mutated != text, "fixture inválida — string esperada não encontrada"
+    target.write_text(mutated, encoding="utf-8")
+    instance = exposure_test.TestPlatformExposureDocs()
+    with pytest.raises(AssertionError):
+        instance.test_claude_declares_external_tester_role()
+
+
+def test_fail_when_codex_missing_no_equivalent_clause(fake_repo) -> None:
+    """Remove menção a '.github/agents/*.agent.md' em .codex → asserção falha."""
+    tmp_path, exposure_test = fake_repo
+    target = tmp_path / ".codex"
+    text = target.read_text(encoding="utf-8")
+    mutated = text.replace(".github/agents/*.agent.md", "REMOVED")
+    assert mutated != text, "fixture inválida — string esperada não encontrada"
+    target.write_text(mutated, encoding="utf-8")
+    instance = exposure_test.TestPlatformExposureDocs()
+    with pytest.raises(AssertionError):
+        instance.test_codex_declares_no_equivalent_agent_ui()
+
+
+def test_fail_when_execution_plan_doc_deleted(fake_repo) -> None:
+    """Remove .dev/AGENT_PLATFORM_EXPOSURE_EXECUTION_PLAN.md → asserção falha."""
+    tmp_path, exposure_test = fake_repo
+    target = tmp_path / ".dev" / "AGENT_PLATFORM_EXPOSURE_EXECUTION_PLAN.md"
+    target.unlink()
+    instance = exposure_test.TestPlatformExposureDocs()
+    with pytest.raises(AssertionError):
+        instance.test_execution_plan_exists_and_disambiguates_other_artifacts()

--- a/tests/pipeline_gates/test_asyncapi_validation_gate_negative.py
+++ b/tests/pipeline_gates/test_asyncapi_validation_gate_negative.py
@@ -1,0 +1,161 @@
+"""
+Negative enforcement tests for ASYNCAPI_VALIDATION_GATE (issue #108).
+
+Cada teste injeta uma violação no asyncapi.yaml, roda
+`_g12_asyncapi_validation(tmp_path)` e asserta que o gate falhou
+com `BLOCKED_ASYNCAPI_INVALID`.
+
+Pattern: tmp_path com node_modules symlink + asyncapi.yaml mutado.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+import yaml
+
+from scripts.contracts.validate import validate_contracts as gates
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+NODE_MODULES = REPO_ROOT / "node_modules"
+
+
+def _ensure_asyncapi_available() -> None:
+    if not NODE_MODULES.exists():
+        pytest.skip("node_modules ausente — rode `npm ci`")
+    if not (NODE_MODULES / ".bin" / "asyncapi").exists():
+        pytest.skip("asyncapi CLI não encontrada em node_modules/.bin")
+
+
+def _seed_workspace(tmp_path: pathlib.Path, doc: dict | str) -> pathlib.Path:
+    (tmp_path / "contracts" / "asyncapi").mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "contracts" / "asyncapi" / "asyncapi.yaml"
+    if isinstance(doc, str):
+        target.write_text(doc, encoding="utf-8")
+    else:
+        target.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+    nm_link = tmp_path / "node_modules"
+    if not nm_link.exists():
+        os.symlink(NODE_MODULES, nm_link, target_is_directory=True)
+    return target
+
+
+def _valid_asyncapi_doc() -> dict:
+    """Documento AsyncAPI 2.6 mínimo válido."""
+    return {
+        "asyncapi": "2.6.0",
+        "info": {"title": "Negative Test Async API", "version": "0.0.1"},
+        "channels": {
+            "training.session.created": {
+                "publish": {
+                    "operationId": "publishTrainingSessionCreated",
+                    "message": {
+                        "name": "TrainingSessionCreated",
+                        "payload": {
+                            "type": "object",
+                            "properties": {
+                                "training_session_id": {"type": "string"},
+                            },
+                            "required": ["training_session_id"],
+                        },
+                    },
+                }
+            }
+        },
+    }
+
+
+def _is_error_infra(result: dict) -> bool:
+    return result.get("blocking_code") == "ERROR_INFRA"
+
+
+def _assert_gate_blocked(result: dict, code: str = "BLOCKED_ASYNCAPI_INVALID") -> None:
+    if _is_error_infra(result):
+        pytest.skip(f"AsyncAPI ERROR_INFRA: {result.get('reason')}")
+    assert result["status"] == "FAIL", (
+        f"esperava FAIL, recebeu {result['status']}: {result.get('reason')}"
+    )
+    assert result.get("blocking_code") == code, (
+        f"esperava blocking_code={code}, recebeu {result.get('blocking_code')}"
+    )
+    assert result.get("violations"), "esperava violations não-vazio"
+
+
+# ---------------------------------------------------------------------------
+# Sanidade
+# ---------------------------------------------------------------------------
+
+def test_baseline_valid_doc_passes(tmp_path: pathlib.Path) -> None:
+    _ensure_asyncapi_available()
+    _seed_workspace(tmp_path, _valid_asyncapi_doc())
+    result = gates._g12_asyncapi_validation(tmp_path)
+    if _is_error_infra(result):
+        pytest.skip(f"AsyncAPI ERROR_INFRA: {result.get('reason')}")
+    assert result["status"] == "PASS", (
+        f"baseline deveria passar — {result.get('reason')} | "
+        f"violations={[v.get('message') for v in result.get('violations', [])]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negativos
+# ---------------------------------------------------------------------------
+
+def test_fail_when_asyncapi_version_field_missing(tmp_path: pathlib.Path) -> None:
+    """Campo top-level 'asyncapi' obrigatório."""
+    _ensure_asyncapi_available()
+    doc = _valid_asyncapi_doc()
+    del doc["asyncapi"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g12_asyncapi_validation(tmp_path)
+    _assert_gate_blocked(result)
+
+
+def test_fail_when_asyncapi_version_unsupported(tmp_path: pathlib.Path) -> None:
+    """Versão AsyncAPI inexistente deve ser rejeitada."""
+    _ensure_asyncapi_available()
+    doc = _valid_asyncapi_doc()
+    doc["asyncapi"] = "9.9.9"
+    _seed_workspace(tmp_path, doc)
+    result = gates._g12_asyncapi_validation(tmp_path)
+    _assert_gate_blocked(result)
+
+
+def test_fail_when_asyncapi_info_title_missing(tmp_path: pathlib.Path) -> None:
+    """info.title é obrigatório por schema AsyncAPI."""
+    _ensure_asyncapi_available()
+    doc = _valid_asyncapi_doc()
+    del doc["info"]["title"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g12_asyncapi_validation(tmp_path)
+    _assert_gate_blocked(result)
+
+
+def test_fail_when_asyncapi_info_version_missing(tmp_path: pathlib.Path) -> None:
+    """info.version é obrigatório por schema AsyncAPI."""
+    _ensure_asyncapi_available()
+    doc = _valid_asyncapi_doc()
+    del doc["info"]["version"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g12_asyncapi_validation(tmp_path)
+    _assert_gate_blocked(result)
+
+
+def test_fail_when_yaml_is_malformed(tmp_path: pathlib.Path) -> None:
+    """YAML sintaticamente inválido deve ser rejeitado."""
+    _ensure_asyncapi_available()
+    bad_yaml = "asyncapi: 2.6.0\ninfo: { title: 'broken\n  invalid: yaml: here\n"
+    _seed_workspace(tmp_path, bad_yaml)
+    result = gates._g12_asyncapi_validation(tmp_path)
+    _assert_gate_blocked(result)
+
+
+def test_fail_when_channels_field_missing(tmp_path: pathlib.Path) -> None:
+    """channels é obrigatório em AsyncAPI 2.x."""
+    _ensure_asyncapi_available()
+    doc = _valid_asyncapi_doc()
+    del doc["channels"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g12_asyncapi_validation(tmp_path)
+    _assert_gate_blocked(result)

--- a/tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py
+++ b/tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py
@@ -1,0 +1,214 @@
+"""
+Negative enforcement tests for OPENAPI_POLICY_RULESET_GATE (issue #108).
+
+Cada teste injeta a violação de uma regra `error` em `.spectral.yaml`,
+roda `_g6_openapi_policy_ruleset(tmp_path)` e asserta que o gate falhou
+com a regra correspondente listada em `violations[]`.
+
+Pattern: tmp_path com .spectral.yaml + node_modules symlink + openapi.yaml mutado.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+
+import pytest
+import yaml
+
+from scripts.contracts.validate import validate_contracts as gates
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPECTRAL_CFG = REPO_ROOT / ".spectral.yaml"
+NODE_MODULES = REPO_ROOT / "node_modules"
+
+
+def _ensure_spectral_available() -> None:
+    if not SPECTRAL_CFG.exists():
+        pytest.skip(".spectral.yaml ausente no repo")
+    if not NODE_MODULES.exists():
+        pytest.skip("node_modules ausente — rode `npm ci` para habilitar spectral")
+    if not (NODE_MODULES / ".bin" / "spectral").exists():
+        pytest.skip("spectral CLI não encontrada em node_modules/.bin")
+
+
+def _seed_workspace(tmp_path: pathlib.Path, openapi_doc: dict) -> pathlib.Path:
+    """Monta um workspace mínimo em tmp_path para o gate consumir."""
+    (tmp_path / "contracts" / "openapi").mkdir(parents=True, exist_ok=True)
+    openapi_file = tmp_path / "contracts" / "openapi" / "openapi.yaml"
+    openapi_file.write_text(yaml.safe_dump(openapi_doc, sort_keys=False), encoding="utf-8")
+    shutil.copy2(SPECTRAL_CFG, tmp_path / ".spectral.yaml")
+    nm_link = tmp_path / "node_modules"
+    if not nm_link.exists():
+        os.symlink(NODE_MODULES, nm_link, target_is_directory=True)
+    return openapi_file
+
+
+def _valid_openapi_doc() -> dict:
+    """Documento OpenAPI 3.1 mínimo que satisfaz todas as regras `error`."""
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Negative Test API", "version": "0.0.1"},
+        "servers": [{"url": "https://api.example.com"}],
+        "tags": [{"name": "training", "description": "Training module"}],
+        "security": [],
+        "paths": {
+            "/training-sessions": {
+                "get": {
+                    "operationId": "listTrainingSessions",
+                    "tags": ["training"],
+                    "responses": {
+                        "200": {"description": "OK"},
+                        "500": {
+                            "description": "Server error",
+                            "content": {
+                                "application/problem+json": {
+                                    "schema": {"$ref": "#/components/schemas/problem"}
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "problem": {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string"},
+                        "title": {"type": "string"},
+                        "status": {"type": "integer"},
+                        "detail": {"type": "string"},
+                    },
+                    "required": ["type", "title", "status"],
+                }
+            }
+        },
+    }
+
+
+def _has_violation_with_code(result: dict, code_substring: str) -> bool:
+    for v in result.get("violations", []):
+        msg = v.get("message", "")
+        if code_substring.lower() in msg.lower():
+            return True
+    return False
+
+
+def _is_error_infra(result: dict) -> bool:
+    return result.get("blocking_code") == "ERROR_INFRA"
+
+
+def _assert_gate_blocked(result: dict, expected_rule: str) -> None:
+    if _is_error_infra(result):
+        pytest.skip(f"Spectral ERROR_INFRA: {result.get('reason')}")
+    assert result["status"] == "FAIL", f"esperava FAIL, recebeu {result['status']}: {result}"
+    assert _has_violation_with_code(result, expected_rule), (
+        f"violação esperada para '{expected_rule}' não encontrada. "
+        f"violations={[v.get('message') for v in result.get('violations', [])]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sanidade: documento válido deve PASSAR (controle positivo)
+# ---------------------------------------------------------------------------
+
+def test_baseline_valid_doc_passes(tmp_path: pathlib.Path) -> None:
+    _ensure_spectral_available()
+    _seed_workspace(tmp_path, _valid_openapi_doc())
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    if _is_error_infra(result):
+        pytest.skip(f"Spectral ERROR_INFRA: {result.get('reason')}")
+    errors = [v for v in result.get("violations", []) if v.get("severity") == "error"]
+    assert not errors, (
+        "documento de baseline deveria passar sem erros — "
+        "investigue se a fixture _valid_openapi_doc() viola alguma regra. "
+        f"errors={[v.get('message') for v in errors]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negativos — uma regra error por teste
+# ---------------------------------------------------------------------------
+
+def test_fail_when_openapi_version_violated(tmp_path: pathlib.Path) -> None:
+    """hbtrack-openapi-version: openapi deve ser 3.1.x"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    doc["openapi"] = "3.0.3"
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-openapi-version")
+
+
+def test_fail_when_operation_id_missing(tmp_path: pathlib.Path) -> None:
+    """hbtrack-operation-id-required: toda operação deve ter operationId"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    del doc["paths"]["/training-sessions"]["get"]["operationId"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-operation-id-required")
+
+
+def test_fail_when_tag_description_missing(tmp_path: pathlib.Path) -> None:
+    """hbtrack-tag-description: toda tag deve ter description"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    doc["tags"] = [{"name": "training"}]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-tag-description")
+
+
+def test_fail_when_uri_versioning_present(tmp_path: pathlib.Path) -> None:
+    """hbtrack-no-uri-versioning: paths com /v1/ são proibidos"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    doc["paths"] = {
+        "/v1/training-sessions": doc["paths"].pop("/training-sessions"),
+    }
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-no-uri-versioning")
+
+
+def test_fail_when_info_title_missing(tmp_path: pathlib.Path) -> None:
+    """hbtrack-info-title: info.title obrigatório"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    del doc["info"]["title"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-info-title")
+
+
+def test_fail_when_info_version_missing(tmp_path: pathlib.Path) -> None:
+    """hbtrack-info-version: info.version obrigatório"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    del doc["info"]["version"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-info-version")
+
+
+def test_fail_when_servers_missing(tmp_path: pathlib.Path) -> None:
+    """hbtrack-servers-defined: servers deve existir"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    del doc["servers"]
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-servers-defined")
+
+
+def test_fail_when_problem_schema_undeclared(tmp_path: pathlib.Path) -> None:
+    """hbtrack-problem-schema-declared: components.schemas.problem obrigatório"""
+    _ensure_spectral_available()
+    doc = _valid_openapi_doc()
+    doc["components"]["schemas"].pop("problem")
+    _seed_workspace(tmp_path, doc)
+    result = gates._g6_openapi_policy_ruleset(tmp_path)
+    _assert_gate_blocked(result, "hbtrack-problem-schema-declared")


### PR DESCRIPTION
## Resumo

PR A da estratégia Frente A × Frente B — prova auditável de que os gates **falham quando devem falhar** antes de corrigir as decisões expostas pelo PR #110.

## O que foi entregue

### Testes negativos (24 total — 3 baselines + 21 negativos)

| Arquivo | Baseline | Negativos | Domínio |
|---|---|---|---|
| `tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py` | 1 | 8 | OPENAPI_POLICY_RULESET_GATE (8 regras `error` de `.spectral.yaml`) |
| `tests/pipeline_gates/test_asyncapi_validation_gate_negative.py` | 1 | 6 | ASYNCAPI_VALIDATION_GATE |
| `tests/pipeline_gates/test_agent_governance_negative_enforcement.py` | 1 | 7 | Agent governance (.github/agents/, frontmatter, bridge docs) |

### Gerador de manifesto
- `scripts/generate_negative_test_manifest.py` → `_reports/implementation_flow/negative_test_manifest.json`
- Schema-valid contra `contracts/schemas/shared/negative_test_manifest.schema.json`
- `verdict=PASS`, `coverage_ratio=1.0` (21/21 PROTECTED)

### CI
- `.github/workflows/contract-gates.yml`: novo job `negative-enforcement` (paralelo a `validate-contracts`)

## Critérios de aceite

- [x] ≥ 6 negative tests para OpenAPI ruleset (8 entregues)
- [x] ≥ 5 negative tests para agent governance (7 entregues)
- [x] ≥ 4 negative tests para AsyncAPI validation (6 entregues)
- [x] Todos passam localmente: 24/24 PASS
- [x] `negative_test_manifest.json` schema-valid, `coverage_ratio=1.0`, `verdict=PASS`
- [x] Pre-commit hook: PARTIAL_PASS (todos os gates aplicáveis em PASS)
- [x] Nenhuma alteração em `.contract_driven/waivers.json`, `_reports/decision_materialization/`, ou contratos canônicos

## Próximos PRs (estratégia Frente B)
- PR B: LIVE_ENFORCEMENT_PARITY_GATE local como ERROR_INFRA
- PR C: waiver hygiene
- PR D: issue #111 — TRAINING_DECISION_MATERIALIZATION_BACKFILL
- PR E: conflitos contratuais R1/R2

Closes #108