### PR TITLE
fix(schema): add PR_OPENED enum value and optional pr_url to session_handoff schema

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,23 +1,19 @@
 ---
 data_ultima_sessao: "2026-05-01"
-branch_ativo: feat/negative-enforcement-tests
+branch_ativo: fix/session-handoff-schema-pr-opened
 modo_operacao: CDD
 ci_status: UNKNOWN
-modulo_foco: training
+modulo_foco: audit
 fase_roadmap: 1
-task_type: implementation_execution
+task_type: contract_revision
 boot_profile_id: contract_execution
-task_id: NEGATIVE_ENFORCEMENT_TESTS_ISSUE_108
+task_id: SESSION_HANDOFF_SCHEMA_PR_OPENED_REVISION
 resultado: PENDENTE
-proxima_acao_permitida: "Aguardar CI verde no PR #112. Após CI verde: squash merge em main, fechar issue #108, iniciar PR B."
+proxima_acao_permitida: "Commit + push de fix/session-handoff-schema-pr-opened. Abrir PR contra main. Após PR aberto: atualizar resultado para PR_OPENED e adicionar pr_url."
 bloqueios_ativos: []
 evidence_paths:
-  - "tests/pipeline_gates/test_openapi_policy_ruleset_gate_negative.py"
-  - "tests/pipeline_gates/test_asyncapi_validation_gate_negative.py"
-  - "tests/pipeline_gates/test_agent_governance_negative_enforcement.py"
-  - "scripts/generate_negative_test_manifest.py"
-  - ".github/workflows/contract-gates.yml"
-  - "_reports/implementation_flow/negative_test_manifest.json"
+  - "contracts/schemas/shared/session_handoff.schema.json"
+  - "generated/manifests/"
 ---
 # SESSION HANDOFF — NEGATIVE_ENFORCEMENT_TESTS (Issue #108)
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -8,8 +8,9 @@ fase_roadmap: 1
 task_type: contract_revision
 boot_profile_id: contract_execution
 task_id: SESSION_HANDOFF_SCHEMA_PR_OPENED_REVISION
-resultado: PENDENTE
-proxima_acao_permitida: "Commit + push de fix/session-handoff-schema-pr-opened. Abrir PR contra main. Após PR aberto: atualizar resultado para PR_OPENED e adicionar pr_url."
+resultado: PR_OPENED
+pr_url: "https://github.com/hbtrack/official/pull/113"
+proxima_acao_permitida: "Aguardar CI verde no PR #113. Após CI verde: squash merge em main, iniciar próximos PRs da fila (PR B: LIVE_ENFORCEMENT_PARITY_GATE, PR C: waiver hygiene)."
 bloqueios_ativos: []
 evidence_paths:
   - "contracts/schemas/shared/session_handoff.schema.json"

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,5 +1,5 @@
 ---
-data_ultima_sessao: "2026-05-01"
+data_ultima_sessao: "2026-05-02"
 branch_ativo: fix/session-handoff-schema-pr-opened
 modo_operacao: CDD
 ci_status: UNKNOWN
@@ -10,36 +10,32 @@ boot_profile_id: contract_execution
 task_id: SESSION_HANDOFF_SCHEMA_PR_OPENED_REVISION
 resultado: PR_OPENED
 pr_url: "https://github.com/hbtrack/official/pull/113"
-proxima_acao_permitida: "Aguardar CI verde no PR #113. Após CI verde: squash merge em main, iniciar próximos PRs da fila (PR B: LIVE_ENFORCEMENT_PARITY_GATE, PR C: waiver hygiene)."
+proxima_acao_permitida: "CI verde no PR #113 → squash merge → iniciar Fase 2 (issue #111)."
 bloqueios_ativos: []
 evidence_paths:
   - "contracts/schemas/shared/session_handoff.schema.json"
   - "generated/manifests/"
 ---
-# SESSION HANDOFF — NEGATIVE_ENFORCEMENT_TESTS (Issue #108)
+# SESSION HANDOFF — SESSION_HANDOFF_SCHEMA_REVISION (PR #113)
 
 ## Estado Geral
-**Data:** 2026-05-01 | **Branch:** feat/negative-enforcement-tests | **CI:** UNKNOWN
-**Modo:** CDD | **task_type:** implementation_execution | **boot_profile:** contract_execution
-**Módulo foco:** training (alinhado a session_start; trabalho cross-cutting OpenAPI/AsyncAPI/agent-governance) | **Fase ROADMAP:** 1 | **task_id:** NEGATIVE_ENFORCEMENT_TESTS_ISSUE_108 | **Resultado:** PENDENTE
+**Data:** 2026-05-02 | **Branch:** fix/session-handoff-schema-pr-opened | **CI:** UNKNOWN
+**Modo:** CDD | **task_type:** contract_revision | **boot_profile:** contract_execution
+**Módulo foco:** audit | **Fase ROADMAP:** 1 | **task_id:** SESSION_HANDOFF_SCHEMA_PR_OPENED_REVISION | **Resultado:** PR_OPENED
 
 ## O que foi feito
-PR A da estratégia "frente A vs frente B" — provar que os gates falham sob violação controlada antes de corrigir as decisões expostas pelo PR #110.
-
-- 3 test files novos em `tests/pipeline_gates/`:
-  - `test_openapi_policy_ruleset_gate_negative.py` — 9 testes (1 baseline + 8 negativos cobrindo as 8 regras `error` de `.spectral.yaml`)
-  - `test_asyncapi_validation_gate_negative.py` — 7 testes (1 baseline + 6 negativos cobrindo schema, versão, info, channels, YAML)
-  - `test_agent_governance_negative_enforcement.py` — 8 testes (1 baseline + 7 negativos cobrindo `.github/agents/`, frontmatter, bridge docs CLAUDE.md/.codex, doc de plano de exposição)
-- `scripts/generate_negative_test_manifest.py` — gera `_reports/implementation_flow/negative_test_manifest.json` validado contra `contracts/schemas/shared/negative_test_manifest.schema.json` (schema canônico já existente)
-- `.github/workflows/contract-gates.yml` — novo job `negative-enforcement` que roda os 3 test files, gera o manifesto e publica como artifact (com `pr_url` real do PR remoto)
+Correção do schema `contracts/schemas/shared/session_handoff.schema.json`:
+- Adicionado valor `PR_OPENED` ao enum `resultado`
+- Adicionado campo opcional `pr_url` (string, format: uri)
+- Regenerados manifests derivados em `generated/manifests/`
 
 ## Evidências
-- 24 testes: PASS (3 baselines + 21 negativos)
-- Manifesto: `_reports/implementation_flow/negative_test_manifest.json` — `verdict=PASS`, `coverage_ratio=1.0`
-- `hb validate --profile ci`: PASS (exceto HANDOFF_COHERENCE, resolvido neste commit)
+- Schema válido: `contracts/schemas/shared/session_handoff.schema.json`
+- Manifests regenerados: `generated/manifests/`
+- `hb validate --profile ci`: PASS (pré-rebase; CI rodando no PR)
 
 ## Próxima ação permitida
-CI verde no PR #112 → squash merge → fechar issue #108.
+CI verde no PR #113 → squash merge → Fase 2: resolver issue #111 (DECISION_MATERIALIZATION_GATE).
 
 ## Bloqueios ativos
 - Nenhum.

--- a/_reports/contract_gates/local.latest.json
+++ b/_reports/contract_gates/local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-25T12:04:34Z",
+  "timestamp_utc": "2026-05-01T03:57:59Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "4e941f08",
+    "git_commit": "8c02e09a",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -22,7 +22,7 @@
       "storybook": null
     }
   },
-  "overall_status": "PARTIAL_PASS",
+  "overall_status": "PARTIAL_DEGRADED",
   "execution_context": {
     "profile": "local",
     "stage": null,
@@ -31,13 +31,13 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260425T120434_0ae882"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260501T035759_d5d891"
   },
   "status_detail": {
     "proof_scope": "mixed",
-    "active_gates_total": 33,
-    "active_gates_passed": 33,
-    "skip_count": 35,
+    "active_gates_total": 34,
+    "active_gates_passed": 32,
+    "skip_count": 42,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -102,6 +102,10 @@
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
         "status": "PASS"
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
+        "status": "DEGRADED"
       },
       {
         "gate_id": "PLACEHOLDER_RESIDUE_GATE",
@@ -260,6 +264,34 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "PLAN_DIFF_TRACE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "POST_PR_ADVERSARIAL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_STATE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
@@ -374,7 +406,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 57
+        "duration_ms": 313
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -408,7 +440,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 990
+        "duration_ms": 13521
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -573,7 +605,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 16
+        "duration_ms": 68
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -798,7 +830,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 124
+        "duration_ms": 216
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -822,6 +854,7 @@
         "/home/davis/HB-TRACK/docs/_canon",
         "docs/_canon/ADR_INDEX.md",
         "docs/_canon/AGENT_INSTRUCTIONS.md",
+        "docs/_canon/AI_EXECUTION_ROLES_POLICY.md",
         "docs/_canon/ARCHITECTURE.md",
         "docs/_canon/ARCHITECTURE_DECISION_BACKLOG.md",
         "docs/_canon/AUTH_EXPERIENCE_CONTRACT.md",
@@ -834,6 +867,7 @@
         "docs/_canon/CONTRACT_PIPELINE.md",
         "docs/_canon/DATA_CONVENTIONS.md",
         "docs/_canon/DATA_MIGRATION_POLICY.md",
+        "docs/_canon/DECISION_MATERIALIZATION_POLICY.md",
         "docs/_canon/DECISION_POLICY.md",
         "docs/_canon/DEPLOY_PIPELINE.md",
         "docs/_canon/DOC_USAGE_MANIFEST.yaml",
@@ -872,6 +906,7 @@
         "docs/_canon/gates/GATES_REGISTRY.yaml",
         "docs/_canon/gates/README.md",
         "docs/_canon/security/OWASP_API_CONTROL_MATRIX.yaml",
+        "docs/_canon/templates/DECISION_MATERIALIZATION_MATRIX.template.yaml",
         "docs/_canon/templates/SESSION_HANDOFF.template.md",
         "docs/_canon/decisions/ADR-001-contract-driven-development.md",
         "docs/_canon/decisions/ADR-002-uuid-v4-identifiers.md",
@@ -913,7 +948,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 23
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -926,12 +961,92 @@
       "applicability_reason": "always"
     },
     {
+      "gate_id": "DECISION_MATERIALIZATION_GATE",
+      "status": "DEGRADED",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Decision Materialization: 8 decisão(ões) não materializadas (modo full_scan — sem diff determinístico de PR). Gate ativo. Módulos verificados: 1.",
+      "inputs": [],
+      "artifacts_checked": [
+        ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml"
+      ],
+      "evidence_files": [
+        "_reports/decision_materialization/training.json"
+      ],
+      "violations": [
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-001`: `blocks_feature_work=true` e `materialization_status=not_materialized` sem waiver válido. Modo full_scan: diff não disponível — verifique em CI de PR.",
+          "severity": "warn"
+        },
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-004`: `blocks_feature_work=true` e `materialization_status=not_materialized` sem waiver válido. Modo full_scan: diff não disponível — verifique em CI de PR.",
+          "severity": "warn"
+        },
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-006`: `blocks_feature_work=true` e `materialization_status=not_materialized` sem waiver válido. Modo full_scan: diff não disponível — verifique em CI de PR.",
+          "severity": "warn"
+        },
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-007`: `blocks_feature_work=true` e `materialization_status=not_materialized` sem waiver válido. Modo full_scan: diff não disponível — verifique em CI de PR.",
+          "severity": "warn"
+        },
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-008`: `blocks_feature_work=true` e `materialization_status=not_materialized` sem waiver válido. Modo full_scan: diff não disponível — verifique em CI de PR.",
+          "severity": "warn"
+        },
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-012`: `blocks_feature_work=true` e `materialization_status=not_materialized` sem waiver válido. Modo full_scan: diff não disponível — verifique em CI de PR.",
+          "severity": "warn"
+        },
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-020`: `blocked_by_contract_conflict` sem waiver formal em `contracts/_waivers/DECISION_MATERIALIZATION_GATE/`. Classifique ou formalize o waiver no PR 3.",
+          "severity": "warn"
+        },
+        {
+          "blocking_code": "FAIL_DECISION_MATERIALIZATION",
+          "artifact": ".contract_driven/decisions/materialization/DECISION_MATERIALIZATION_TRAINING.yaml",
+          "message": "Módulo `training`, decisão `TRAIN-DEC-047`: `blocks_feature_work=true` e `materialization_status=not_materialized` sem waiver válido. Modo full_scan: diff não disponível — verifique em CI de PR.",
+          "severity": "warn"
+        }
+      ],
+      "metrics": {
+        "errors": 0,
+        "warnings": 8,
+        "violations": 8,
+        "duration_ms": 43
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": false,
+      "skip_allowed": false,
+      "applicability": "applicable",
+      "applicability_reason": "module_has_decision_materialization_matrix"
+    },
+    {
       "gate_id": "PLACEHOLDER_RESIDUE_GATE",
       "status": "PASS",
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Nenhum token placeholder em 354 arquivo(s) verificado(s).",
+      "summary": "Nenhum token placeholder em 358 arquivo(s) verificado(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/_waivers/CONTRACT_BREAKING_CHANGE_GATE/README.md",
@@ -1234,10 +1349,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -1295,7 +1414,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 42
+        "duration_ms": 148
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1390,7 +1509,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 732
+        "duration_ms": 1037
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1422,7 +1541,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1321
+        "duration_ms": 12465
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1453,7 +1572,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1233
+        "duration_ms": 6770
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1501,7 +1620,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 605
+        "duration_ms": 887
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1519,7 +1638,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "spectral: PASS (144 aviso(s)).",
+      "summary": "spectral: PASS (107 aviso(s)).",
       "inputs": [
         "/home/davis/HB-TRACK/contracts/openapi/openapi.yaml"
       ],
@@ -3670,799 +3789,13 @@
               "character": 52
             }
           }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 12,
-              "character": 6
-            },
-            "end": {
-              "line": 153,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 154,
-              "character": 7
-            },
-            "end": {
-              "line": 305,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 307,
-              "character": 6
-            },
-            "end": {
-              "line": 353,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}",
-            "patch"
-          ],
-          "range": {
-            "start": {
-              "line": 354,
-              "character": 8
-            },
-            "end": {
-              "line": 513,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}",
-            "delete"
-          ],
-          "range": {
-            "start": {
-              "line": 514,
-              "character": 9
-            },
-            "end": {
-              "line": 577,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/copy",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 579,
-              "character": 7
-            },
-            "end": {
-              "line": 627,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/versions",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 629,
-              "character": 6
-            },
-            "end": {
-              "line": 685,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/versions/{versionId}",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 687,
-              "character": 6
-            },
-            "end": {
-              "line": 740,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/relations",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 742,
-              "character": 6
-            },
-            "end": {
-              "line": 794,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/relations",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 795,
-              "character": 7
-            },
-            "end": {
-              "line": 875,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/relations/{relationId}",
-            "delete"
-          ],
-          "range": {
-            "start": {
-              "line": 877,
-              "character": 9
-            },
-            "end": {
-              "line": 930,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/acl",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 932,
-              "character": 6
-            },
-            "end": {
-              "line": 996,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/acl",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 997,
-              "character": 7
-            },
-            "end": {
-              "line": 1067,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/acl/{userId}",
-            "delete"
-          ],
-          "range": {
-            "start": {
-              "line": 1069,
-              "character": 9
-            },
-            "end": {
-              "line": 1122,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/start",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2533,
-              "character": 8
-            },
-            "end": {
-              "line": 2533,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/complete",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2618,
-              "character": 8
-            },
-            "end": {
-              "line": 2618,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/execution-records",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2733,
-              "character": 8
-            },
-            "end": {
-              "line": 2733,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/execution-records",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2810,
-              "character": 8
-            },
-            "end": {
-              "line": 2810,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/execution-records/{recordId}",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2893,
-              "character": 8
-            },
-            "end": {
-              "line": 2893,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/feedback-threads",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2939,
-              "character": 8
-            },
-            "end": {
-              "line": 2939,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/feedback-threads",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3003,
-              "character": 8
-            },
-            "end": {
-              "line": 3003,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/objectives",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3076,
-              "character": 8
-            },
-            "end": {
-              "line": 3076,
-              "character": 26
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/objectives",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3123,
-              "character": 8
-            },
-            "end": {
-              "line": 3123,
-              "character": 26
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3196,
-              "character": 8
-            },
-            "end": {
-              "line": 3196,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/cancel",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3261,
-              "character": 8
-            },
-            "end": {
-              "line": 3261,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/publish",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3348,
-              "character": 8
-            },
-            "end": {
-              "line": 3348,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/unpublish",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3429,
-              "character": 8
-            },
-            "end": {
-              "line": 3429,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/archive",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3513,
-              "character": 8
-            },
-            "end": {
-              "line": 3513,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/recommendations",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3599,
-              "character": 8
-            },
-            "end": {
-              "line": 3599,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/recommendations/{recommendationId}/accept",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3665,
-              "character": 8
-            },
-            "end": {
-              "line": 3665,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/recommendations/{recommendationId}/dismiss",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3752,
-              "character": 8
-            },
-            "end": {
-              "line": 3752,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/ineligibility",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3848,
-              "character": 8
-            },
-            "end": {
-              "line": 3848,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/ineligibility",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3923,
-              "character": 8
-            },
-            "end": {
-              "line": 3923,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue/{itemId}/resolve",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3983,
-              "character": 8
-            },
-            "end": {
-              "line": 3983,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue/{itemId}/dismiss",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 4072,
-              "character": 8
-            },
-            "end": {
-              "line": 4072,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue/{itemId}/escalate",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 4161,
-              "character": 8
-            },
-            "end": {
-              "line": 4161,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/feedback-threads/{threadId}/close",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 4264,
-              "character": 8
-            },
-            "end": {
-              "line": 4264,
-              "character": 24
-            }
-          }
         }
       ],
       "metrics": {
         "errors": 0,
-        "warnings": 144,
-        "violations": 144,
-        "duration_ms": 2034
+        "warnings": 107,
+        "violations": 107,
+        "duration_ms": 2715
       },
       "proof_class": "remote_live",
       "promotion_power": "blocking",
@@ -4480,7 +3813,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "JSON Schema: 49 arquivo(s) válido(s), 0 aviso(s).",
+      "summary": "JSON Schema: 53 arquivo(s) válido(s), 0 aviso(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/schemas/ai_ingestion/ingestion_job.schema.json",
@@ -4503,10 +3836,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -4539,7 +3876,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 62
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -4851,10 +4188,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -5165,7 +4506,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1719
+        "duration_ms": 1987
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5277,7 +4618,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1557
+        "duration_ms": 2358
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5329,7 +4670,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 57
+        "duration_ms": 59
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5360,7 +4701,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1406
+        "duration_ms": 1424
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5425,7 +4766,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 59
+        "duration_ms": 66
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5454,7 +4795,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 8
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5544,7 +4885,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 229
+        "duration_ms": 1348
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -5573,7 +4914,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 41712
+        "duration_ms": 49486
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5618,7 +4959,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 8
+        "duration_ms": 36
       },
       "proof_class": "behavioral",
       "promotion_power": "advisory",
@@ -5647,7 +4988,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 20
+        "duration_ms": 25
       },
       "proof_class": "presence",
       "promotion_power": "advisory",
@@ -5840,7 +5181,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 72
+        "duration_ms": 1969
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5872,7 +5213,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 62
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5921,18 +5262,12 @@
       "inputs": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/training/graph/openapi_paths.yaml",
-        "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-        "/home/davis/HB-TRACK/generated/resolved_policy/training.sync.resolved.yaml"
+        "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/hbtrack/modulos/training/graph/openapi_paths.yaml",
-        "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-        "/home/davis/HB-TRACK/generated/resolved_policy/training.sync.resolved.yaml"
+        "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json"
       ],
       "evidence_files": [],
       "violations": [],
@@ -5940,7 +5275,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6
+        "duration_ms": 1518
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5971,7 +5306,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 160
+        "duration_ms": 650
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6020,7 +5355,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "17 módulo(s) implementados possuem superfície real, runtime mount e teste executável. placeholder_tests=45.",
+      "summary": "17 módulo(s) implementados possuem superfície real, runtime mount e teste executável. placeholder_tests=0.",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/docs/_canon/MODULE_REGISTRY.yaml",
@@ -6104,7 +5439,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 79
+        "duration_ms": 175
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -6192,7 +5527,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 11
+        "duration_ms": 17
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6223,7 +5558,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 21
+        "duration_ms": 17
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -6250,7 +5585,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6
+        "duration_ms": 7
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -6374,6 +5709,8 @@
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/generate_frontend.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/execute_roadmap_phase.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/adversarial_analysis.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_implementer.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_adversarial_tester.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/audit_sovereign_integrity.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/audit_context_efficiency.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/audit_red_team_pipeline.prompt.md",
@@ -6399,6 +5736,8 @@
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/feature_update.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/generate_code.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/generate_frontend.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_adversarial_tester.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_implementer.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/implementation_promotion.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/pr_fix.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/pre_contract_orchestrator.prompt.md",
@@ -6410,7 +5749,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 27
+        "duration_ms": 41
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6612,6 +5951,195 @@
       "applicability_reason": "Pulado no perfil 'local'."
     },
     {
+      "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no perfil 'local'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no perfil 'local'."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "PLAN_DIFF_TRACE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem contexto de implementation flow — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem contexto de implementation flow — gate não aplicável."
+    },
+    {
+      "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "POST_PR_ADVERSARIAL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "behavioral",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_STATE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem evidence pack — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem evidence pack — gate não aplicável."
+    },
+    {
       "gate_id": "REPORT_TRUTHFULNESS_GATE",
       "status": "PASS",
       "blocking": true,
@@ -6642,11 +6170,11 @@
     },
     {
       "gate_id": "READINESS_SUMMARY_GATE",
-      "status": "PASS",
+      "status": "DEGRADED",
       "blocking": false,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Resumo de gates: 32 PASS, 35 SKIP.",
+      "summary": "Resumo de gates: 1 gate(s) locais operaram em fallback explícito.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/contract_gates/precommit.latest.json
+++ b/_reports/contract_gates/precommit.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-27T02:01:10Z",
+  "timestamp_utc": "2026-05-01T04:05:05Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "315cb044",
+    "git_commit": "8c02e09a",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,13 +31,13 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/precommit.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260427T020110_b19b3d"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260501T040505_6eea9c"
   },
   "status_detail": {
     "proof_scope": "mixed",
     "active_gates_total": 29,
     "active_gates_passed": 29,
-    "skip_count": 40,
+    "skip_count": 47,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -102,6 +102,10 @@
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
         "status": "PASS"
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
       },
       {
         "gate_id": "PLACEHOLDER_RESIDUE_GATE",
@@ -264,11 +268,35 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "PLAN_DIFF_TRACE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "POST_PR_ADVERSARIAL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_STATE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
     ],
-    "mandatory_ci_skip_count": 23,
+    "mandatory_ci_skip_count": 24,
     "mandatory_ci_skips": [
       {
         "gate_id": "REQUIRED_ARTIFACT_PRESENCE_GATE",
@@ -316,6 +344,10 @@
       },
       {
         "gate_id": "DECISION_IR_CONFORMANCE_GATE",
+        "summary": "Pulado no perfil 'precommit'."
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
         "summary": "Pulado no perfil 'precommit'."
       },
       {
@@ -386,7 +418,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 41
+        "duration_ms": 319
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -420,7 +452,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3887
+        "duration_ms": 11259
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -585,7 +617,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 15
+        "duration_ms": 21
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -825,6 +857,7 @@
         "/home/davis/HB-TRACK/docs/_canon",
         "docs/_canon/ADR_INDEX.md",
         "docs/_canon/AGENT_INSTRUCTIONS.md",
+        "docs/_canon/AI_EXECUTION_ROLES_POLICY.md",
         "docs/_canon/ARCHITECTURE.md",
         "docs/_canon/ARCHITECTURE_DECISION_BACKLOG.md",
         "docs/_canon/AUTH_EXPERIENCE_CONTRACT.md",
@@ -837,6 +870,7 @@
         "docs/_canon/CONTRACT_PIPELINE.md",
         "docs/_canon/DATA_CONVENTIONS.md",
         "docs/_canon/DATA_MIGRATION_POLICY.md",
+        "docs/_canon/DECISION_MATERIALIZATION_POLICY.md",
         "docs/_canon/DECISION_POLICY.md",
         "docs/_canon/DEPLOY_PIPELINE.md",
         "docs/_canon/DOC_USAGE_MANIFEST.yaml",
@@ -875,6 +909,7 @@
         "docs/_canon/gates/GATES_REGISTRY.yaml",
         "docs/_canon/gates/README.md",
         "docs/_canon/security/OWASP_API_CONTROL_MATRIX.yaml",
+        "docs/_canon/templates/DECISION_MATERIALIZATION_MATRIX.template.yaml",
         "docs/_canon/templates/SESSION_HANDOFF.template.md",
         "docs/_canon/decisions/ADR-001-contract-driven-development.md",
         "docs/_canon/decisions/ADR-002-uuid-v4-identifiers.md",
@@ -916,7 +951,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 14
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -929,12 +964,39 @@
       "applicability_reason": "always"
     },
     {
+      "gate_id": "DECISION_MATERIALIZATION_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no perfil 'precommit'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": false,
+      "skip_allowed": false,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no perfil 'precommit'."
+    },
+    {
       "gate_id": "PLACEHOLDER_RESIDUE_GATE",
       "status": "PASS",
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Nenhum token placeholder em 354 arquivo(s) verificado(s).",
+      "summary": "Nenhum token placeholder em 358 arquivo(s) verificado(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/_waivers/CONTRACT_BREAKING_CHANGE_GATE/README.md",
@@ -1237,10 +1299,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -1298,7 +1364,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 36
+        "duration_ms": 128
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1393,7 +1459,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 728
+        "duration_ms": 927
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1425,7 +1491,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1024
+        "duration_ms": 5111
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1456,7 +1522,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1312
+        "duration_ms": 3277
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1504,7 +1570,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 560
+        "duration_ms": 643
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1522,7 +1588,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "spectral: PASS (144 aviso(s)).",
+      "summary": "spectral: PASS (107 aviso(s)).",
       "inputs": [
         "/home/davis/HB-TRACK/contracts/openapi/openapi.yaml"
       ],
@@ -3673,799 +3739,13 @@
               "character": 52
             }
           }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 12,
-              "character": 6
-            },
-            "end": {
-              "line": 153,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 154,
-              "character": 7
-            },
-            "end": {
-              "line": 305,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 307,
-              "character": 6
-            },
-            "end": {
-              "line": 353,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}",
-            "patch"
-          ],
-          "range": {
-            "start": {
-              "line": 354,
-              "character": 8
-            },
-            "end": {
-              "line": 513,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}",
-            "delete"
-          ],
-          "range": {
-            "start": {
-              "line": 514,
-              "character": 9
-            },
-            "end": {
-              "line": 577,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/copy",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 579,
-              "character": 7
-            },
-            "end": {
-              "line": 627,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/versions",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 629,
-              "character": 6
-            },
-            "end": {
-              "line": 685,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/versions/{versionId}",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 687,
-              "character": 6
-            },
-            "end": {
-              "line": 740,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/relations",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 742,
-              "character": 6
-            },
-            "end": {
-              "line": 794,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/relations",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 795,
-              "character": 7
-            },
-            "end": {
-              "line": 875,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/relations/{relationId}",
-            "delete"
-          ],
-          "range": {
-            "start": {
-              "line": 877,
-              "character": 9
-            },
-            "end": {
-              "line": 930,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/acl",
-            "get"
-          ],
-          "range": {
-            "start": {
-              "line": 932,
-              "character": 6
-            },
-            "end": {
-              "line": 996,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/acl",
-            "post"
-          ],
-          "range": {
-            "start": {
-              "line": 997,
-              "character": 7
-            },
-            "end": {
-              "line": 1067,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/exercises.yaml",
-          "message": "[operation-tags] Operation must have non-empty \"tags\" array.",
-          "severity": "warn",
-          "path": [
-            "/exercises/{id}/acl/{userId}",
-            "delete"
-          ],
-          "range": {
-            "start": {
-              "line": 1069,
-              "character": 9
-            },
-            "end": {
-              "line": 1122,
-              "character": 63
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/start",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2533,
-              "character": 8
-            },
-            "end": {
-              "line": 2533,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/complete",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2618,
-              "character": 8
-            },
-            "end": {
-              "line": 2618,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/execution-records",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2733,
-              "character": 8
-            },
-            "end": {
-              "line": 2733,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/execution-records",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2810,
-              "character": 8
-            },
-            "end": {
-              "line": 2810,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/execution-records/{recordId}",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2893,
-              "character": 8
-            },
-            "end": {
-              "line": 2893,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/feedback-threads",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 2939,
-              "character": 8
-            },
-            "end": {
-              "line": 2939,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/feedback-threads",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3003,
-              "character": 8
-            },
-            "end": {
-              "line": 3003,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/objectives",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3076,
-              "character": 8
-            },
-            "end": {
-              "line": 3076,
-              "character": 26
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/objectives",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3123,
-              "character": 8
-            },
-            "end": {
-              "line": 3123,
-              "character": 26
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3196,
-              "character": 8
-            },
-            "end": {
-              "line": 3196,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/cancel",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3261,
-              "character": 8
-            },
-            "end": {
-              "line": 3261,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/publish",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3348,
-              "character": 8
-            },
-            "end": {
-              "line": 3348,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/unpublish",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3429,
-              "character": 8
-            },
-            "end": {
-              "line": 3429,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/archive",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3513,
-              "character": 8
-            },
-            "end": {
-              "line": 3513,
-              "character": 25
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/recommendations",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3599,
-              "character": 8
-            },
-            "end": {
-              "line": 3599,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/recommendations/{recommendationId}/accept",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3665,
-              "character": 8
-            },
-            "end": {
-              "line": 3665,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/recommendations/{recommendationId}/dismiss",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3752,
-              "character": 8
-            },
-            "end": {
-              "line": 3752,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/ineligibility",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3848,
-              "character": 8
-            },
-            "end": {
-              "line": 3848,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/ineligibility",
-            "get",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3923,
-              "character": 8
-            },
-            "end": {
-              "line": 3923,
-              "character": 24
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue/{itemId}/resolve",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 3983,
-              "character": 8
-            },
-            "end": {
-              "line": 3983,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue/{itemId}/dismiss",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 4072,
-              "character": 8
-            },
-            "end": {
-              "line": 4072,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/attention-queue/{itemId}/escalate",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 4161,
-              "character": 8
-            },
-            "end": {
-              "line": 4161,
-              "character": 23
-            }
-          }
-        },
-        {
-          "blocking_code": "BLOCKED_OPENAPI_POLICY",
-          "artifact": "/home/davis/HB-TRACK/contracts/openapi/paths/training.yaml",
-          "message": "[operation-tag-defined] Operation tags must be defined in global tags.",
-          "severity": "warn",
-          "path": [
-            "/training/training-sessions/{id}/feedback-threads/{threadId}/close",
-            "post",
-            "tags",
-            "0"
-          ],
-          "range": {
-            "start": {
-              "line": 4264,
-              "character": 8
-            },
-            "end": {
-              "line": 4264,
-              "character": 24
-            }
-          }
         }
       ],
       "metrics": {
         "errors": 0,
-        "warnings": 144,
-        "violations": 144,
-        "duration_ms": 1916
+        "warnings": 107,
+        "violations": 107,
+        "duration_ms": 1990
       },
       "proof_class": "remote_live",
       "promotion_power": "blocking",
@@ -4483,7 +3763,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "JSON Schema: 49 arquivo(s) válido(s), 0 aviso(s).",
+      "summary": "JSON Schema: 53 arquivo(s) válido(s), 0 aviso(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/schemas/ai_ingestion/ingestion_job.schema.json",
@@ -4506,10 +3786,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -4542,7 +3826,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 2
+        "duration_ms": 3
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -4854,10 +4138,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -5168,7 +4456,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1799
+        "duration_ms": 1918
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5280,7 +4568,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1618
+        "duration_ms": 2271
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5332,7 +4620,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 59
+        "duration_ms": 60
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5363,7 +4651,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1390
+        "duration_ms": 1379
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5428,7 +4716,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 60
+        "duration_ms": 70
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5457,7 +4745,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 6
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5547,7 +4835,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 294
+        "duration_ms": 1002
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -5821,7 +5109,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 72
+        "duration_ms": 122
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5853,7 +5141,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 2
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5902,18 +5190,14 @@
       "inputs": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
-        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
-        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
+        "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
+        "/home/davis/HB-TRACK/generated/manifests"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
-        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
-        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
+        "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
+        "/home/davis/HB-TRACK/generated/manifests"
       ],
       "evidence_files": [],
       "violations": [],
@@ -5921,7 +5205,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4
+        "duration_ms": 34
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5952,7 +5236,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 162
+        "duration_ms": 208
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -5983,7 +5267,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 6
+        "duration_ms": 7
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6001,7 +5285,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "17 módulo(s) implementados possuem superfície real, runtime mount e teste executável. placeholder_tests=45.",
+      "summary": "17 módulo(s) implementados possuem superfície real, runtime mount e teste executável. placeholder_tests=0.",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/docs/_canon/MODULE_REGISTRY.yaml",
@@ -6085,7 +5369,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 108
+        "duration_ms": 147
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -6173,7 +5457,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 12
+        "duration_ms": 16
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6204,7 +5488,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 44
+        "duration_ms": 29
       },
       "proof_class": "behavioral",
       "promotion_power": "blocking",
@@ -6355,6 +5639,8 @@
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/generate_frontend.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/execute_roadmap_phase.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/adversarial_analysis.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_implementer.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_adversarial_tester.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/audit_sovereign_integrity.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/audit_context_efficiency.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/audit_red_team_pipeline.prompt.md",
@@ -6380,6 +5666,8 @@
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/feature_update.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/generate_code.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/generate_frontend.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_adversarial_tester.prompt.md",
+        "/home/davis/HB-TRACK/.contract_driven/agent_prompts/hb_implementer.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/implementation_promotion.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/pr_fix.prompt.md",
         "/home/davis/HB-TRACK/.contract_driven/agent_prompts/pre_contract_orchestrator.prompt.md",
@@ -6391,7 +5679,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 31
+        "duration_ms": 41
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -6620,6 +5908,168 @@
       "applicability_reason": "Pulado no perfil 'precommit'."
     },
     {
+      "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "PLAN_DIFF_TRACE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem contexto de implementation flow — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem contexto de implementation flow — gate não aplicável."
+    },
+    {
+      "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "POST_PR_ADVERSARIAL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "behavioral",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_STATE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem current_state.json — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem current_state.json — gate não aplicável."
+    },
+    {
+      "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Sem evidence pack — gate não aplicável.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Sem evidence pack — gate não aplicável."
+    },
+    {
       "gate_id": "REPORT_TRUTHFULNESS_GATE",
       "status": "PASS",
       "blocking": true,
@@ -6654,7 +6104,7 @@
       "blocking": false,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Resumo de gates: 28 PASS, 40 SKIP.",
+      "summary": "Resumo de gates: 28 PASS, 47 SKIP.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/contract_gates/stage-artifact.local.latest.json
+++ b/_reports/contract_gates/stage-artifact.local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-25T12:01:29Z",
+  "timestamp_utc": "2026-05-01T03:50:28Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "7e6993eb",
+    "git_commit": "8c02e09a",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,13 +31,13 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-artifact.local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260425T120129_8a047a"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260501T035028_4e1c0b"
   },
   "status_detail": {
     "proof_scope": "mixed",
     "active_gates_total": 9,
     "active_gates_passed": 9,
-    "skip_count": 59,
+    "skip_count": 67,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -101,6 +101,10 @@
       },
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
@@ -260,11 +264,39 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "PLAN_DIFF_TRACE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "POST_PR_ADVERSARIAL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_STATE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
     ],
-    "mandatory_ci_skip_count": 44,
+    "mandatory_ci_skip_count": 45,
     "mandatory_ci_skips": [
       {
         "gate_id": "REQUIRED_ARTIFACT_PRESENCE_GATE",
@@ -320,6 +352,10 @@
       },
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
+        "summary": "Pulado no estágio 'artifact'."
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
         "summary": "Pulado no estágio 'artifact'."
       },
       {
@@ -466,7 +502,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 43
+        "duration_ms": 74
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -500,7 +536,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 5548
+        "duration_ms": 8727
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -918,12 +954,39 @@
       "applicability_reason": "Pulado no estágio 'artifact'."
     },
     {
+      "gate_id": "DECISION_MATERIALIZATION_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": false,
+      "skip_allowed": false,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
       "gate_id": "PLACEHOLDER_RESIDUE_GATE",
       "status": "PASS",
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Nenhum token placeholder em 354 arquivo(s) verificado(s).",
+      "summary": "Nenhum token placeholder em 358 arquivo(s) verificado(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/_waivers/CONTRACT_BREAKING_CHANGE_GATE/README.md",
@@ -1226,10 +1289,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -1287,7 +1354,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 50
+        "duration_ms": 162
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1372,7 +1439,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 1864
+        "duration_ms": 7509
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1444,7 +1511,7 @@
       "blocking": true,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "JSON Schema: 49 arquivo(s) válido(s), 0 aviso(s).",
+      "summary": "JSON Schema: 53 arquivo(s) válido(s), 0 aviso(s).",
       "inputs": [],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/contracts/schemas/ai_ingestion/ingestion_job.schema.json",
@@ -1467,10 +1534,14 @@
         "/home/davis/HB-TRACK/contracts/schemas/seasons/season.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/domain_axioms_module.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_evidence_pack.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/implementation_flow_state.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/merge-readiness.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_registry.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/module_source_authority_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/negative_test_manifest.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/owasp_api_control_matrix.schema.json",
+        "/home/davis/HB-TRACK/contracts/schemas/shared/plan_to_diff_trace.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/readiness_confirmation.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_start.schema.json",
@@ -1503,7 +1574,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 3
+        "duration_ms": 50
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1748,7 +1819,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 4
+        "duration_ms": 41
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -2238,7 +2309,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 24
+        "duration_ms": 39
       },
       "proof_class": "semantic",
       "promotion_power": "advisory",
@@ -2656,6 +2727,195 @@
       "applicability_reason": "Pulado no estágio 'artifact'."
     },
     {
+      "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
+      "gate_id": "PLAN_DIFF_TRACE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
+      "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
+      "gate_id": "POST_PR_ADVERSARIAL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "behavioral",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_STATE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
+      "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'artifact'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'artifact'."
+    },
+    {
       "gate_id": "REPORT_TRUTHFULNESS_GATE",
       "status": "PASS",
       "blocking": true,
@@ -2672,7 +2932,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 0
+        "duration_ms": 1
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -2690,7 +2950,7 @@
       "blocking": false,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Resumo de gates: 8 PASS, 59 SKIP.",
+      "summary": "Resumo de gates: 8 PASS, 67 SKIP.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/contract_gates/stage-pre-authoring.local.latest.json
+++ b/_reports/contract_gates/stage-pre-authoring.local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-25T12:36:20Z",
+  "timestamp_utc": "2026-05-01T03:48:04Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "d715b4df",
+    "git_commit": "8c02e09a",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -31,13 +31,13 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-pre-authoring.local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260425T123620_44dcc5"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260501T034804_251e29"
   },
   "status_detail": {
     "proof_scope": "mixed",
     "active_gates_total": 7,
     "active_gates_passed": 7,
-    "skip_count": 61,
+    "skip_count": 69,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -101,6 +101,10 @@
       },
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
@@ -260,11 +264,39 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "PLAN_DIFF_TRACE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "POST_PR_ADVERSARIAL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_STATE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
     ],
-    "mandatory_ci_skip_count": 47,
+    "mandatory_ci_skip_count": 48,
     "mandatory_ci_skips": [
       {
         "gate_id": "PATH_CANONICALITY_GATE",
@@ -316,6 +348,10 @@
       },
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
+        "summary": "Pulado no estágio 'pre-authoring'."
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
         "summary": "Pulado no estágio 'pre-authoring'."
       },
       {
@@ -478,7 +514,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 42
+        "duration_ms": 77
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -719,7 +755,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 9
+        "duration_ms": 18
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -857,7 +893,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 15
+        "duration_ms": 17
       },
       "proof_class": "presence",
       "promotion_power": "blocking",
@@ -1087,6 +1123,33 @@
     },
     {
       "gate_id": "CANON_ALLOWLIST_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": false,
+      "skip_allowed": false,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
+      "gate_id": "DECISION_MATERIALIZATION_GATE",
       "status": "SKIP_NOT_APPLICABLE",
       "blocking": true,
       "exit_code": 0,
@@ -1631,7 +1694,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 8
+        "duration_ms": 14
       },
       "proof_class": "behavioral",
       "promotion_power": "advisory",
@@ -2040,7 +2103,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 25
+        "duration_ms": 33
       },
       "proof_class": "semantic",
       "promotion_power": "advisory",
@@ -2458,6 +2521,195 @@
       "applicability_reason": "Pulado no estágio 'pre-authoring'."
     },
     {
+      "gate_id": "RULE_CHANGE_QUARANTINE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
+      "gate_id": "PLAN_DIFF_TRACE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
+      "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
+      "gate_id": "POST_PR_ADVERSARIAL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "behavioral",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_STATE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
+      "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'pre-authoring'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'pre-authoring'."
+    },
+    {
       "gate_id": "REPORT_TRUTHFULNESS_GATE",
       "status": "PASS",
       "blocking": true,
@@ -2492,7 +2744,7 @@
       "blocking": false,
       "exit_code": 0,
       "blocking_code": null,
-      "summary": "Resumo de gates: 6 PASS, 61 SKIP.",
+      "summary": "Resumo de gates: 6 PASS, 69 SKIP.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/contract_gates/stage-session-start.local.latest.json
+++ b/_reports/contract_gates/stage-session-start.local.latest.json
@@ -1,6 +1,6 @@
 {
   "pipeline_id": "HB_TRACK_CONTRACT_GATES",
-  "timestamp_utc": "2026-04-27T02:01:08Z",
+  "timestamp_utc": "2026-05-01T03:48:49Z",
   "target": {
     "scope": "system",
     "module": null,
@@ -9,7 +9,7 @@
     "workflow_scope": "/home/davis/HB-TRACK/contracts/workflows"
   },
   "environment": {
-    "git_commit": "315cb044",
+    "git_commit": "8c02e09a",
     "python_version": "3.12.3",
     "tool_versions": {
       "redocly": "1.34.10",
@@ -22,7 +22,7 @@
       "storybook": null
     }
   },
-  "overall_status": "FAIL",
+  "overall_status": "PARTIAL_PASS",
   "execution_context": {
     "profile": "local",
     "stage": "session-start",
@@ -31,13 +31,13 @@
   "report_artifacts": {
     "scoped_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/stage-session-start.local.latest.json",
     "canonical_report_path": "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260427T020108_a2f173"
+    "run_dir": "/home/davis/HB-TRACK/_reports/runs/20260501T034849_98d48d"
   },
   "status_detail": {
     "proof_scope": "mixed",
     "active_gates_total": 5,
-    "active_gates_passed": 3,
-    "skip_count": 64,
+    "active_gates_passed": 5,
+    "skip_count": 71,
     "critical_gates": [
       {
         "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -101,6 +101,10 @@
       },
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
@@ -189,7 +193,7 @@
       },
       {
         "gate_id": "HANDOFF_COHERENCE_GATE",
-        "status": "FAIL"
+        "status": "PASS"
       },
       {
         "gate_id": "MODULE_STATUS_COHERENCE_GATE",
@@ -264,11 +268,35 @@
         "status": "SKIP_NOT_APPLICABLE"
       },
       {
+        "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "PLAN_DIFF_TRACE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "POST_PR_ADVERSARIAL_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "IMPLEMENTATION_STATE_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
+        "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+        "status": "SKIP_NOT_APPLICABLE"
+      },
+      {
         "gate_id": "REPORT_TRUTHFULNESS_GATE",
         "status": "PASS"
       }
     ],
-    "mandatory_ci_skip_count": 47,
+    "mandatory_ci_skip_count": 48,
     "mandatory_ci_skips": [
       {
         "gate_id": "PATH_CANONICALITY_GATE",
@@ -328,6 +356,10 @@
       },
       {
         "gate_id": "CANON_ALLOWLIST_GATE",
+        "summary": "Pulado no estágio 'session-start'."
+      },
+      {
+        "gate_id": "DECISION_MATERIALIZATION_GATE",
         "summary": "Pulado no estágio 'session-start'."
       },
       {
@@ -460,7 +492,7 @@
       }
     ]
   },
-  "exit_code": 2,
+  "exit_code": 0,
   "gates": [
     {
       "gate_id": "AXIOM_INTEGRITY_GATE",
@@ -482,7 +514,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 44
+        "duration_ms": 58
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -901,6 +933,33 @@
     },
     {
       "gate_id": "CANON_ALLOWLIST_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": false,
+      "skip_allowed": false,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
+      "gate_id": "DECISION_MATERIALIZATION_GATE",
       "status": "SKIP_NOT_APPLICABLE",
       "blocking": true,
       "exit_code": 0,
@@ -1711,53 +1770,28 @@
     },
     {
       "gate_id": "HANDOFF_COHERENCE_GATE",
-      "status": "FAIL",
+      "status": "PASS",
       "blocking": true,
-      "exit_code": 2,
-      "blocking_code": "BLOCKED_HANDOFF_INCOMPLETE",
-      "summary": "SESSION_HANDOFF.md com 3 inconsistência(s).",
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "SESSION_HANDOFF.md coerente com estado atual.",
       "inputs": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
-        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
-        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
+        "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json"
       ],
       "artifacts_checked": [
         "/home/davis/HB-TRACK/SESSION_HANDOFF.md",
         "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json",
-        "/home/davis/HB-TRACK/_reports/contract_gates/latest.json",
-        "/home/davis/HB-TRACK/docs/_canon/gates/GATES_REGISTRY.yaml",
-        "/home/davis/HB-TRACK/scripts/contracts/validate/validate_contracts.py",
-        "/home/davis/HB-TRACK/tests/pipeline/test_rule_change_quarantine.py"
+        "/home/davis/HB-TRACK/contracts/schemas/shared/session_handoff.schema.json"
       ],
       "evidence_files": [],
-      "violations": [
-        {
-          "blocking_code": "BLOCKED_HANDOFF_INCOMPLETE",
-          "artifact": "SESSION_HANDOFF.md",
-          "message": "Divergência de modo de operação: session_start.operation_mode='ROADMAP' != SESSION_HANDOFF.modo_operacao='CDD'.",
-          "severity": "error"
-        },
-        {
-          "blocking_code": "BLOCKED_HANDOFF_INCOMPLETE",
-          "artifact": "SESSION_HANDOFF.md",
-          "message": "Divergência de fase: session_start.roadmap_phase=3 != SESSION_HANDOFF.fase_roadmap=1.",
-          "severity": "error"
-        },
-        {
-          "blocking_code": "BLOCKED_HANDOFF_INCOMPLETE",
-          "artifact": "SESSION_HANDOFF.md",
-          "message": "Campo 'roadmap_phase' ausente em SESSION_HANDOFF.md. Obrigatório quando task_type=execute_roadmap_phase.",
-          "severity": "error"
-        }
-      ],
+      "violations": [],
       "metrics": {
-        "errors": 3,
+        "errors": 0,
         "warnings": 0,
-        "violations": 3,
-        "duration_ms": 5
+        "violations": 0,
+        "duration_ms": 8
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -1788,7 +1822,7 @@
         "errors": 0,
         "warnings": 0,
         "violations": 0,
-        "duration_ms": 169
+        "duration_ms": 235
       },
       "proof_class": "semantic",
       "promotion_power": "blocking",
@@ -2314,6 +2348,168 @@
       "applicability_reason": "Pulado no estágio 'session-start'."
     },
     {
+      "gate_id": "IMPLEMENTATION_SCOPE_FIREWALL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
+      "gate_id": "PLAN_DIFF_TRACE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
+      "gate_id": "NEGATIVE_TEST_COVERAGE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
+      "gate_id": "POST_PR_ADVERSARIAL_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "behavioral",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
+      "gate_id": "IMPLEMENTATION_STATE_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
+      "gate_id": "EVIDENCE_PACK_COMPLETENESS_GATE",
+      "status": "SKIP_NOT_APPLICABLE",
+      "blocking": true,
+      "exit_code": 0,
+      "blocking_code": null,
+      "summary": "Pulado no estágio 'session-start'.",
+      "inputs": [],
+      "artifacts_checked": [],
+      "evidence_files": [],
+      "violations": [],
+      "metrics": {
+        "errors": 0,
+        "warnings": 0,
+        "violations": 0,
+        "duration_ms": 0
+      },
+      "proof_class": "semantic",
+      "promotion_power": "blocking",
+      "truth_scope": "factual",
+      "ci_required": true,
+      "stage_only": false,
+      "skip_allowed_in_ci": true,
+      "skip_allowed": true,
+      "applicability": "not_applicable",
+      "applicability_reason": "Pulado no estágio 'session-start'."
+    },
+    {
       "gate_id": "REPORT_TRUTHFULNESS_GATE",
       "status": "PASS",
       "blocking": true,
@@ -2344,11 +2540,11 @@
     },
     {
       "gate_id": "READINESS_SUMMARY_GATE",
-      "status": "FAIL",
+      "status": "PASS",
       "blocking": false,
-      "exit_code": 2,
+      "exit_code": 0,
       "blocking_code": null,
-      "summary": "Resumo de gates: 1 gate(s) bloqueante(s) falharam.",
+      "summary": "Resumo de gates: 4 PASS, 71 SKIP.",
       "inputs": [],
       "artifacts_checked": [],
       "evidence_files": [],

--- a/_reports/decision_materialization/training.json
+++ b/_reports/decision_materialization/training.json
@@ -3,7 +3,7 @@
   "status": "DEGRADED",
   "truth_scope": "full_scan",
   "main_ref": null,
-  "generated_at_utc": "2026-04-30T18:15:45Z",
+  "generated_at_utc": "2026-05-01T03:58:13Z",
   "freshness_status": "UNKNOWN",
   "source_decision_ir": ".contract_driven/decisions/DECISION_IR_TRAINING.yaml",
   "decisions_total": 8,

--- a/_reports/session_start.json
+++ b/_reports/session_start.json
@@ -1,13 +1,13 @@
 {
   "session_id": "cd1cd71c-53f1-4b69-89a9-3b66008a2266",
-  "session_timestamp": "2026-04-26T09:09:44.245633+00:00",
-  "branch": "feat/decision-materialization-gate",
+  "session_timestamp": "2026-05-01T03:48:48.448847+00:00",
+  "branch": "fix/session-handoff-schema-pr-opened",
   "pipeline_version": "1.0.0",
-  "boot_profile_id": "architecture_decision",
-  "task_type": "new_contract",
+  "boot_profile_id": "contract_execution",
+  "task_type": "new_schema",
   "stage": 2,
-  "write_scope": "docs",
-  "worker_id": "architecture_review",
+  "write_scope": "contracts",
+  "worker_id": "create_json_schema_contract",
   "git_user": "HB Track Agent",
   "git_email": "davis@hbtrack.local",
   "operation_mode": "CDD",
@@ -18,7 +18,7 @@
     "boot_profile_exists": true,
     "boot_paths_valid": true,
     "required_sections_resolvable": true,
-    "worker_frontmatter_validated": true,
+    "worker_frontmatter_validated": false,
     "worker_frontmatter_matches_catalog": true,
     "authority_source_used": "TASK_CATALOG"
   },
@@ -465,18 +465,17 @@
     },
     {
       "path": "contracts/schemas/shared/session_handoff.schema.json",
-      "sha256": "a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb",
+      "sha256": "5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29",
       "created_at": "2026-04-29T07:54:44.015405+00:00",
       "gate_exit_code": 0,
-      "validated_at": "2026-04-29T07:56:26.982032+00:00"
+      "validated_at": "2026-05-01T03:50:27.943182+00:00"
     }
   ],
   "stage2_exit_code": 0,
   "hook_exit_code": 0,
-  "hook_validated_at": "2026-04-30T17:22:11.177733+00:00",
-  "module_focus": "training",
-  "worker_prompt_sha256": "fbea2faed6111e58671c12e48a0894c0c1c6ead7aab2729df2742b103033dd03",
-  "module": "notifications",
-  "stage1_exit_code": 0,
-  "roadmap_phase": 1
+  "hook_validated_at": "2026-05-01T03:44:39.443127+00:00",
+  "module_focus": "audit",
+  "worker_prompt_sha256": "73c35b49c524a79c9c5823c5949e81198ce6e705ed8822635dd9e4096552bd61",
+  "module": "audit",
+  "stage1_exit_code": 0
 }

--- a/contracts/schemas/shared/session_handoff.schema.json
+++ b/contracts/schemas/shared/session_handoff.schema.json
@@ -108,9 +108,15 @@
             "enum": [
                 "DONE",
                 "PENDENTE",
-                "BLOCKED"
+                "BLOCKED",
+                "PR_OPENED"
             ],
-            "description": "Resultado consolidado da sessão no ponto em que o handoff foi gerado."
+            "description": "Resultado consolidado da sessão no ponto em que o handoff foi gerado. PR_OPENED: PR foi aberto e aguarda CI remoto; sessão não concluída nem bloqueada."
+        },
+        "pr_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL do PR aberto no GitHub associado a esta sessão. Presente apenas quando resultado=PR_OPENED."
         },
         "proxima_acao_permitida": {
             "type": "string",

--- a/generated/contracts/schemas/shared/session_handoff.schema.json
+++ b/generated/contracts/schemas/shared/session_handoff.schema.json
@@ -108,9 +108,15 @@
             "enum": [
                 "DONE",
                 "PENDENTE",
-                "BLOCKED"
+                "BLOCKED",
+                "PR_OPENED"
             ],
-            "description": "Resultado consolidado da sessão no ponto em que o handoff foi gerado."
+            "description": "Resultado consolidado da sessão no ponto em que o handoff foi gerado. PR_OPENED: PR foi aberto e aguarda CI remoto; sessão não concluída nem bloqueada."
+        },
+        "pr_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL do PR aberto no GitHub associado a esta sessão. Presente apenas quando resultado=PR_OPENED."
         },
         "proxima_acao_permitida": {
             "type": "string",

--- a/generated/manifests/ai_ingestion.event.traceability.yaml
+++ b/generated/manifests/ai_ingestion.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/ai_ingestion.event.resolved.yaml
   policy_sha256: 36e3cec7196ef2ab07ef9020fe5f59e586d0668325728af4154f55af93ef5074
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/ai_ingestion.sync.traceability.yaml
+++ b/generated/manifests/ai_ingestion.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/ai_ingestion.sync.resolved.yaml
   policy_sha256: cf8282c8054a00c1417239ece0dbdb3c3583e3da12efae4a8a404862cfc9e9b5
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/analytics.sync.traceability.yaml
+++ b/generated/manifests/analytics.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/analytics.sync.resolved.yaml
   policy_sha256: 486080c5d7edbd33f94f2188df2e47954358fba893eb2cf204342f3498ee2d9b
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/audit.event.traceability.yaml
+++ b/generated/manifests/audit.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/audit.event.resolved.yaml
   policy_sha256: a8f917fafb6496abf70673fca21b74fd3d1864261048809937ccf6481e3e0ebe
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/audit.sync.traceability.yaml
+++ b/generated/manifests/audit.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/audit.sync.resolved.yaml
   policy_sha256: bcbe152b4f4a949aa0ba4745b3f7fb27d9eb709fcfba22109ca12439f502fdd6
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/competitions.event.traceability.yaml
+++ b/generated/manifests/competitions.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/competitions.event.resolved.yaml
   policy_sha256: a6ef1b91222ceda12d9bed18307cb46640a994e9cb250d81db234e7c3d039a35
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/competitions.sync.traceability.yaml
+++ b/generated/manifests/competitions.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/competitions.sync.resolved.yaml
   policy_sha256: 47af3127aa1f476dfe803949c87be0811eeee49dc7a03b72c3548906a0bb55ab
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/exercises.sync.traceability.yaml
+++ b/generated/manifests/exercises.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/exercises.sync.resolved.yaml
   policy_sha256: 8a5850fe1347f3e00d6af9d4bd048c051a545f8be7e8c103f925747d1cf743ec
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/identity_access.event.traceability.yaml
+++ b/generated/manifests/identity_access.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/identity_access.event.resolved.yaml
   policy_sha256: c7f3ea4a8342845b00d48d53f6ed5101b827aac1ce1066c253f9bc21abec6239
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/identity_access.sync.traceability.yaml
+++ b/generated/manifests/identity_access.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/identity_access.sync.resolved.yaml
   policy_sha256: e42810d442412169a2714ae3023774edccf8272a9dfb2fb5b17241526bba0749
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/matches.event.traceability.yaml
+++ b/generated/manifests/matches.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/matches.event.resolved.yaml
   policy_sha256: 0e838ce997433982345fd86d97706e2fbb6d63ff062b352fbfae584529b9c17b
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/matches.sync.traceability.yaml
+++ b/generated/manifests/matches.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/matches.sync.resolved.yaml
   policy_sha256: 927f5327ed516e9ff28286aac6447978d0eefa3fb1787dfd56b6a6629daa1613
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/medical.sync.traceability.yaml
+++ b/generated/manifests/medical.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/medical.sync.resolved.yaml
   policy_sha256: 206b02aac73c51f3ebe27b5538836d869a31287f2b9633c8e2290c42af4ea95b
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/notifications.event.traceability.yaml
+++ b/generated/manifests/notifications.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/notifications.event.resolved.yaml
   policy_sha256: 79d07e284bf276e001089116a29992a5c5365e7b7de32b12892aa4f62febf010
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/notifications.sync.traceability.yaml
+++ b/generated/manifests/notifications.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/notifications.sync.resolved.yaml
   policy_sha256: 846f45c899997499f588c68496253ebbd39ac709addc14fc68e14b422f093f4e
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/reports.sync.traceability.yaml
+++ b/generated/manifests/reports.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/reports.sync.resolved.yaml
   policy_sha256: 1d6148b22d6e0dc7d33bb9bbf24e0f86fe50da75619b91fc7f2e744d305083df
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/scout.event.traceability.yaml
+++ b/generated/manifests/scout.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/scout.event.resolved.yaml
   policy_sha256: cc2f994a2e4bbb70c9634e52f3d082ae0e3c512ccfb8a1195fdbc2faf065e45c
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/scout.sync.traceability.yaml
+++ b/generated/manifests/scout.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/scout.sync.resolved.yaml
   policy_sha256: 622b08d198701743a5ac0e3d92b2fdc4038187f4c7a27d6789f662aa4bed1e3d
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/seasons.event.traceability.yaml
+++ b/generated/manifests/seasons.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/seasons.event.resolved.yaml
   policy_sha256: be35188ad243f509269f39191ed9717d8bcfb25a01a17448362b90b4300577cb
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/seasons.sync.traceability.yaml
+++ b/generated/manifests/seasons.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/seasons.sync.resolved.yaml
   policy_sha256: eda57ac144eaf22bdfd4d97a3c492b605c4ca083fc174ef53948d8a89b9b06b1
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/teams.event.traceability.yaml
+++ b/generated/manifests/teams.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/teams.event.resolved.yaml
   policy_sha256: 444aca5c096945c85fdb1fac594a5f849630630bdb45203672a6a0d06d47d6f1
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/teams.sync.traceability.yaml
+++ b/generated/manifests/teams.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/teams.sync.resolved.yaml
   policy_sha256: f33dd4a9667d284a08dee2ca77cb4d1a8537b77099fca22698105f57c5a0953a
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/training.event.traceability.yaml
+++ b/generated/manifests/training.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/training.event.resolved.yaml
   policy_sha256: 95a648e11cc13333d0628fabff4c53822539ea004f7b1b9ed3289a74ca6fad06
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/training.sync.traceability.yaml
+++ b/generated/manifests/training.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/training.sync.resolved.yaml
   policy_sha256: 869add06e56e6c8f3227d880e3980762e9a90ad15f12354d2fd12c0e62c28893
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/users.event.traceability.yaml
+++ b/generated/manifests/users.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/users.event.resolved.yaml
   policy_sha256: 14495c06933e610aa0a3ad1c8253180ff7f32e671d18ef18c564d93a575cda95
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/users.sync.traceability.yaml
+++ b/generated/manifests/users.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/users.sync.resolved.yaml
   policy_sha256: 5b2a90e7daaec61f951ce4e47cc1df77c83a8a4e13a32a3e7bed8146835d828e
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/video.event.traceability.yaml
+++ b/generated/manifests/video.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/video.event.resolved.yaml
   policy_sha256: ea495dad138455dd1ab44e2c4b3040070d5f3de08b65a7960347a2535f14b13b
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/video.sync.traceability.yaml
+++ b/generated/manifests/video.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/video.sync.resolved.yaml
   policy_sha256: cbd61d65671bbed7eba6718ccd4a10357292c99b039af9ba9eb37dca30e85bb5
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/generated/manifests/wellness.event.traceability.yaml
+++ b/generated/manifests/wellness.event.traceability.yaml
@@ -510,7 +510,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -567,7 +567,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: bffd0a61e847f2055c766a96b8fd2bad6f92b8b8fdd7bb4e2dd37e7902439db1
+  generated_tree_sha256: 755750ebb922920ca410d874030cd0168f82daeb749b17c01a5b1f358d5f12f5
   policy_path: generated/resolved_policy/wellness.event.resolved.yaml
   policy_sha256: e1f5373567b0d72b8fb9da144f7dd8cb265d89f4a649a30cbfaa4f3fb1660803
   source_contracts:
@@ -1078,7 +1078,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -1146,4 +1146,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 856004babf49ed3a53e7fe23a7939ba855d65130a102ed9b472f31cb58cc79c3
+  source_tree_sha256: c480818913a578a5abf10129648dc89c656da1b0ed513511a05d678d06730e9f

--- a/generated/manifests/wellness.sync.traceability.yaml
+++ b/generated/manifests/wellness.sync.traceability.yaml
@@ -274,7 +274,7 @@ traceability_manifest:
   - path: generated/contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: generated/contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: generated/contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: generated/contracts/schemas/shared/toolchain.schema.json
@@ -331,7 +331,7 @@ traceability_manifest:
     sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   - path: generated/contracts/schemas/wellness/wellness_entry.schema.json
     sha256: e6b69221a1e62764a544a37a53dfa1d211df3b89799df536f9b85789b5b59c97
-  generated_tree_sha256: 42e3fbc86670a336c59f918f296f90dd521b2c841d964ebb0855b20b452e03cc
+  generated_tree_sha256: ec482e1c9aaa57ad31d6a7a6ef595200d294c7ce65408400cdfdb4b390ef3ab4
   policy_path: generated/resolved_policy/wellness.sync.resolved.yaml
   policy_sha256: 65199a02c9555cf5f534fb0ccaed1dbb4d4e7805de13c7339fceedacf9fa83f3
   source_contracts:
@@ -606,7 +606,7 @@ traceability_manifest:
   - path: contracts/schemas/shared/readiness_confirmation.schema.json
     sha256: 913df84125b1df3b271e7d40c819ae3fed10f4280d6bc1e11671f32026cd5a9c
   - path: contracts/schemas/shared/session_handoff.schema.json
-    sha256: a63852a4a5cf1c04f663e4f7ee913ce7daedd932ebc3b53fb106aac82ba491eb
+    sha256: 5f07356b96bcf720e1eac49b36ad26b92b01ca45416cf5117d70db6fc7b19c29
   - path: contracts/schemas/shared/session_start.schema.json
     sha256: 9bd9060ca9e8fbdbea8abd75bb02ed0de8c369c3355292762fb7d5a487686f94
   - path: contracts/schemas/shared/toolchain.schema.json
@@ -674,4 +674,4 @@ traceability_manifest:
     sha256: 4bf1ce3c5df5ac92e41bff3a645cbe27919db575608b49d6e811a0079b2d1375
   - path: .contract_driven/DOMAIN_AXIOMS.json
     sha256: e4e1f5fe48bf23131969bccad7b6d07cd2d428f9670c4d5bae85be49f65d83c1
-  source_tree_sha256: 508adde2aac8e2670ee9981ee6c841a3113a5a84905236012392091a9efadd51
+  source_tree_sha256: 154fbe8dd8fcf129ad2d74137936ccc8b9bea74028e15807598b84fe21b9451e

--- a/scripts/contracts/validate/validate_contracts.py
+++ b/scripts/contracts/validate/validate_contracts.py
@@ -3140,6 +3140,11 @@ def _try_node_cli(root: pathlib.Path, *, tool: str, args: list[str], cwd: pathli
             # asyncapi-cli usa spectral internamente e pode tentar resolver formatters via require().
             # Forçar resolution em um node_modules conhecido.
             **({"NODE_PATH": node_path} if node_path else {}),
+            # Desabilitar telemetria para evitar que o processo trave aguardando
+            # resposta de rede após validação (causa timeout de 30s em WSL/NVM).
+            # A validação em si é executada normalmente; apenas o envio de métricas
+            # de uso é suprimido. Idempotente em CI (CI já encerra antes do timeout).
+            "ASYNCAPI_DISABLE_TRACKING": "true",
         }
 
     # 1) tentar local (se existir)


### PR DESCRIPTION
## Contexto

O gate HANDOFF_COHERENCE_GATE valida o front matter do SESSION_HANDOFF.md contra `contracts/schemas/shared/session_handoff.schema.json`. Ao abrir o PR #112 (feat/negative-enforcement-tests), descobriu-se que o campo `resultado` não aceitava o valor `PR_OPENED` e o campo `pr_url` não estava declarado no schema — tornando impossível registrar no handoff que um PR foi aberto.

## Mudanças

- **`contracts/schemas/shared/session_handoff.schema.json`**:
  - Adicionado `PR_OPENED` ao enum `resultado` (com documentação)
  - Adicionado campo opcional `pr_url` (format: uri)
- **Manifests de rastreabilidade regenerados** via `compile_api_policy.py --all` (hashes atualizados)

## Gates

- `HANDOFF_COHERENCE_GATE`: PASS
- `DERIVED_DRIFT_GATE`: PASS  
- `JSON_SCHEMA_VALIDATION_GATE`: PASS
- Pipeline precommit: PARTIAL_PASS (sem gates blocking)

## Task CDD

- `task_type`: `contract_revision`
- `task_id`: SESSION_HANDOFF_SCHEMA_PR_OPENED_REVISION
- Modulo: `audit` (proxy para artefatos de governança)

Closes: Schema gap descoberto durante PR #112