### PR TITLE
fix(openapi): harden contract quality lint rules

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -129,7 +129,7 @@ rules:
       security global deve estar declarado (pode ser []) para default-deny explícito
       (API5:2023 BFLA — nunca depender de ausência do campo como proteção).
     message: "security global deve ser declarado explicitamente (mesmo que [])"
-    severity: warn
+    severity: error
     formats: [oas3]
     given: "$"
     then:
@@ -142,7 +142,7 @@ rules:
       Segmentos de path devem usar kebab-case (api_rules.yaml §canonical_conventions).
       Parâmetros de path ({id}) são excluídos.
     message: "Segmento de path deve ser kebab-case: {{value}}"
-    severity: warn
+    severity: error
     formats: [oas3]
     given: "$.paths.*~"
     then:
@@ -154,7 +154,7 @@ rules:
   # ── 10. Tags root devem existir quando há operações ───────────────────────
   hbtrack-tags-array-defined:
     description: "tags array deve estar declarado no root quando houver módulos."
-    severity: warn
+    severity: error
     formats: [oas3]
     given: "$"
     then:

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -14,7 +14,7 @@ apis:
 
 rules:
   # Estrutura obrigatória
-  info-license: warn
+  info-license: error
   no-invalid-media-type-examples: warn
   no-unresolved-refs: error
 
@@ -26,13 +26,13 @@ rules:
   # Descrições
   operation-description: warn
   operation-summary: warn
-  tag-description: warn
-  no-empty-servers: warn
+  tag-description: error
+  no-empty-servers: error
 
   # Segurança
   # Validado no root (openapi.yaml define securitySchemes.HTTPBearer);
   # path files são sempre referenciados pelo root e não declaram securitySchemes.
-  security-defined: warn
+  security-defined: error
 
   # Schema
   no-invalid-schema-examples: warn


### PR DESCRIPTION
## Objetivo

Primeiro passo para corrigir os contratos de API sem aceitar falso positivo de lint.

Este PR promove para bloqueante regras OpenAPI que hoje estavam como `warn`, mas que o `contracts/openapi/openapi.yaml` atual já declara de forma explícita:

- licença em `info.license`
- tags root com descrição
- servers declarados
- security global explícita
- tags array root
- path naming kebab-case

## O que muda

### `redocly.yaml`

Promovido para `error`:

- `info-license`
- `tag-description`
- `no-empty-servers`
- `security-defined`

Mantido como `warn` por enquanto:

- `operation-description`
- `operation-summary`
- `no-invalid-media-type-examples`
- `no-invalid-schema-examples`

Motivo: essas regras precisam de medição por operação/exemplo antes de promoção segura, para não misturar hardening de gate com correção massiva de contrato.

### `.spectral.yaml`

Promovido para `error`:

- `hbtrack-security-global-explicit`
- `hbtrack-paths-kebab-case`
- `hbtrack-tags-array-defined`

Mantido como `warn`:

- `oas3-schema`, por comentário existente sobre falso positivo com refs externos.

## O que este PR NÃO faz

- Não corrige ainda summaries/descriptions por operação.
- Não corrige examples/schema examples.
- Não altera paths, schemas ou runtime.
- Não declara qualidade completa do contrato.

## Validação obrigatória antes de ready-for-review

Executar local/CI:

```bash
npm run contracts:lint
python3 scripts/hb validate --profile ci
```

Critério de aceite:

- Redocly passa com as novas severidades.
- Spectral passa com as novas severidades.
- `_reports/contract_gates/latest.json` mostra `OPENAPI_ROOT_STRUCTURE_GATE` e `OPENAPI_POLICY_RULESET_GATE` sem regressão.

## Risco intencional

Se este PR falhar por violação real, a correção correta é ajustar o contrato ou a regra com evidência, não rebaixar para `warn` sem justificativa canônica.
