### PR TITLE
chore(handoff): reconcile SESSION_HANDOFF + remove expired CI-VALIDATE-TIMING waiver

### DIFF
--- a/.contract_driven/waivers.json
+++ b/.contract_driven/waivers.json
@@ -8,17 +8,6 @@
       "approved_by": "arquitetura",
       "date": "2026-04-24",
       "status": "N/A"
-    },
-    {
-      "waiver_id": "CI-VALIDATE-TIMING",
-      "item": "ci/validate-contracts-timing",
-      "title": "Timing issue: CI checks iniciados antes do push completar",
-      "reason": "Github Actions dispara checks quando PR é criado. Alguns jobs (ci/Validate Contracts, Validate Contract Gates) podem ser acionados antes do último commit (fix SESSION_HANDOFF) ser completamente sincronizado ao remote. Fix confirmado localmente (validate --profile ci PASS). Waiver permite merge conforme checks iniciais passam + teste local confirmado.",
-      "approved_by": "pipeline-engineering",
-      "date": "2026-04-25",
-      "status": "temporary",
-      "until": "2026-04-26",
-      "tracked_in": "PR#92"
     }
   ]
 }

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,41 +1,41 @@
 ---
 data_ultima_sessao: "2026-05-02"
-branch_ativo: fix/session-handoff-schema-pr-opened
+branch_ativo: fix/phase1-cleanup-post-merge
 modo_operacao: CDD
 ci_status: UNKNOWN
 modulo_foco: audit
 fase_roadmap: 1
 task_type: contract_revision
 boot_profile_id: contract_execution
-task_id: SESSION_HANDOFF_SCHEMA_PR_OPENED_REVISION
-resultado: PR_OPENED
-pr_url: "https://github.com/hbtrack/official/pull/113"
-proxima_acao_permitida: "CI verde no PR #113 → squash merge → iniciar Fase 2 (issue #111)."
+task_id: PHASE1_POST_MERGE_CLEANUP
+resultado: DONE
+proxima_acao_permitida: "Iniciar Fase 2: triage DECISION_MATERIALIZATION_TRAINING.yaml (issue #111)."
 bloqueios_ativos: []
 evidence_paths:
-  - "contracts/schemas/shared/session_handoff.schema.json"
-  - "generated/manifests/"
+  - "_reports/contract_gates/latest.json"
+  - "_reports/implementation_flow/negative_test_manifest.json"
 ---
-# SESSION HANDOFF — SESSION_HANDOFF_SCHEMA_REVISION (PR #113)
+# SESSION HANDOFF — PHASE1_POST_MERGE_CLEANUP
 
 ## Estado Geral
-**Data:** 2026-05-02 | **Branch:** fix/session-handoff-schema-pr-opened | **CI:** UNKNOWN
+**Data:** 2026-05-02 | **Branch:** fix/phase1-cleanup-post-merge | **CI:** UNKNOWN
 **Modo:** CDD | **task_type:** contract_revision | **boot_profile:** contract_execution
-**Módulo foco:** audit | **Fase ROADMAP:** 1 | **task_id:** SESSION_HANDOFF_SCHEMA_PR_OPENED_REVISION | **Resultado:** PR_OPENED
+**Módulo foco:** audit | **Fase ROADMAP:** 1 | **task_id:** PHASE1_POST_MERGE_CLEANUP | **Resultado:** DONE
 
 ## O que foi feito
-Correção do schema `contracts/schemas/shared/session_handoff.schema.json`:
-- Adicionado valor `PR_OPENED` ao enum `resultado`
-- Adicionado campo opcional `pr_url` (string, format: uri)
-- Regenerados manifests derivados em `generated/manifests/`
+Fase 1 concluída — PRs #114, #112 e #113 mergeados em main (squash):
+- #114: hardening de regras de lint OpenAPI (Redocly + Spectral)
+- #112: 24 testes de enforcement negativo (OpenAPI, AsyncAPI, agent governance)
+- #113: schema `session_handoff` + `PR_OPENED` enum + `ASYNCAPI_DISABLE_TRACKING`
+
+Waiver expirado `CI-VALIDATE-TIMING` (PR#92, until 2026-04-26) removido.
 
 ## Evidências
-- Schema válido: `contracts/schemas/shared/session_handoff.schema.json`
-- Manifests regenerados: `generated/manifests/`
-- `hb validate --profile ci`: PASS (pré-rebase; CI rodando no PR)
+- CI: todos os checks PASS nos 3 merges
+- Testes negativos: `_reports/implementation_flow/negative_test_manifest.json`
 
 ## Próxima ação permitida
-CI verde no PR #113 → squash merge → Fase 2: resolver issue #111 (DECISION_MATERIALIZATION_GATE).
+Iniciar Fase 2: triage `DECISION_MATERIALIZATION_TRAINING.yaml` — 8 decisões em violação (issue #111).
 
 ## Bloqueios ativos
 - Nenhum.


### PR DESCRIPTION
## Contexto
PRs #114, #112, #113 foram mergeados em main (Fase 1 completa).

## Mudanças
- `SESSION_HANDOFF.md`: reconciliado para estado pós-Fase-1 — resultado=DONE, próxima ação = Fase 2 (issue #111)
- `.contract_driven/waivers.json`: remoção do waiver `CI-VALIDATE-TIMING` (expirado em 2026-04-26, referente ao PR#92 já mergeado)

## Gates
- Pre-commit: ✅ PASS (survival-suite 129/1 skipped, schema/template parity, cross-validation all PASS)
- `WAIVER_VALIDITY_GATE`: ✅ PASS após remoção